### PR TITLE
Added Message type Camt-53 to possible return value

### DIFF
--- a/src/DecoderInterface.php
+++ b/src/DecoderInterface.php
@@ -2,12 +2,13 @@
 namespace Genkgo\Camt;
 
 use DOMDocument;
+use Genkgo\Camt\Camt053\Message;
 
 interface DecoderInterface
 {
     /**
      * @param DOMDocument $document
-     * @return mixed
+     * @return mixed|Message
      */
     public function decode(DOMDocument $document);
 }

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -3,6 +3,7 @@ namespace Genkgo\Camt;
 
 use DOMDocument;
 use Genkgo\Camt\Exception\ReaderException;
+use Genkgo\Camt\Camt053\Message;
 
 /**
  * Class Reader
@@ -25,7 +26,7 @@ class Reader
 
     /**
      * @param DOMDocument $document
-     * @return mixed
+     * @return mixed|Message
      * @throws ReaderException
      */
     public function readDom(DOMDocument $document)
@@ -41,7 +42,7 @@ class Reader
 
     /**
      * @param $string
-     * @return mixed
+     * @return mixed|Message
      * @throws ReaderException
      */
     public function readString($string)
@@ -53,7 +54,7 @@ class Reader
 
     /**
      * @param $file
-     * @return mixed
+     * @return mixed|Message
      * @throws ReaderException
      */
     public function readFile($file)


### PR DESCRIPTION
Camt053 Message type added to PHPDoc return value. 
When new types are supported, these can be added as well. 

Helps with type hinting in IDE's