### PR TITLE
Refactorize Decoder

### DIFF
--- a/src/Camt053/DTO/Account.php
+++ b/src/Camt053/DTO/Account.php
@@ -1,5 +1,6 @@
 <?php
-namespace Genkgo\Camt\Camt053;
+
+namespace Genkgo\Camt\Camt053\DTO;
 
 use Genkgo\Camt\Iban;
 

--- a/src/Camt053/DTO/AdditionalTransactionInformation.php
+++ b/src/Camt053/DTO/AdditionalTransactionInformation.php
@@ -1,5 +1,6 @@
 <?php
-namespace Genkgo\Camt\Camt053;
+
+namespace Genkgo\Camt\Camt053\DTO;
 
 class AdditionalTransactionInformation
 {

--- a/src/Camt053/DTO/Address.php
+++ b/src/Camt053/DTO/Address.php
@@ -1,5 +1,6 @@
 <?php
-namespace Genkgo\Camt\Camt053;
+
+namespace Genkgo\Camt\Camt053\DTO;
 
 /**
  * Class Address

--- a/src/Camt053/DTO/Balance.php
+++ b/src/Camt053/DTO/Balance.php
@@ -1,5 +1,6 @@
 <?php
-namespace Genkgo\Camt\Camt053;
+
+namespace Genkgo\Camt\Camt053\DTO;
 
 use DateTimeImmutable;
 use Money\Money;

--- a/src/Camt053/DTO/Creditor.php
+++ b/src/Camt053/DTO/Creditor.php
@@ -1,11 +1,12 @@
 <?php
-namespace Genkgo\Camt\Camt053;
+
+namespace Genkgo\Camt\Camt053\DTO;
 
 /**
- * Class Debtor
+ * Class Creditor
  * @package Genkgo\Camt\Camt053
  */
-class Debtor implements RelatedPartyTypeInterface
+class Creditor implements RelatedPartyTypeInterface
 {
     /**
      * @var string

--- a/src/Camt053/DTO/CreditorReferenceInformation.php
+++ b/src/Camt053/DTO/CreditorReferenceInformation.php
@@ -1,5 +1,6 @@
 <?php
-namespace Genkgo\Camt\Camt053;
+
+namespace Genkgo\Camt\Camt053\DTO;
 
 /**
  * Class CreditorReferenceInformation

--- a/src/Camt053/DTO/Debtor.php
+++ b/src/Camt053/DTO/Debtor.php
@@ -1,11 +1,12 @@
 <?php
-namespace Genkgo\Camt\Camt053;
+
+namespace Genkgo\Camt\Camt053\DTO;
 
 /**
- * Class Creditor
+ * Class Debtor
  * @package Genkgo\Camt\Camt053
  */
-class Creditor implements RelatedPartyTypeInterface
+class Debtor implements RelatedPartyTypeInterface
 {
     /**
      * @var string

--- a/src/Camt053/DTO/Entry.php
+++ b/src/Camt053/DTO/Entry.php
@@ -1,5 +1,6 @@
 <?php
-namespace Genkgo\Camt\Camt053;
+
+namespace Genkgo\Camt\Camt053\DTO;
 
 use BadMethodCallException;
 use DateTimeImmutable;

--- a/src/Camt053/DTO/EntryTransactionDetail.php
+++ b/src/Camt053/DTO/EntryTransactionDetail.php
@@ -1,5 +1,6 @@
 <?php
-namespace Genkgo\Camt\Camt053;
+
+namespace Genkgo\Camt\Camt053\DTO;
 
 use BadMethodCallException;
 

--- a/src/Camt053/DTO/GroupHeader.php
+++ b/src/Camt053/DTO/GroupHeader.php
@@ -1,5 +1,6 @@
 <?php
-namespace Genkgo\Camt\Camt053;
+
+namespace Genkgo\Camt\Camt053\DTO;
 
 /**
  * Class GroupHeader

--- a/src/Camt053/DTO/Message.php
+++ b/src/Camt053/DTO/Message.php
@@ -1,5 +1,6 @@
 <?php
-namespace Genkgo\Camt\Camt053;
+
+namespace Genkgo\Camt\Camt053\DTO;
 
 use Genkgo\Camt\Camt053\Iterator\EntryIterator;
 

--- a/src/Camt053/DTO/Reference.php
+++ b/src/Camt053/DTO/Reference.php
@@ -1,5 +1,6 @@
 <?php
-namespace Genkgo\Camt\Camt053;
+
+namespace Genkgo\Camt\Camt053\DTO;
 
 /**
  * Class Reference

--- a/src/Camt053/DTO/Reference.php
+++ b/src/Camt053/DTO/Reference.php
@@ -19,8 +19,8 @@ class Reference
     private $mandateId;
 
     /**
-     * @param $endToEndId
-     * @param $mandateId
+     * @param string $endToEndId
+     * @param string $mandateId
      */
     public function __construct($endToEndId, $mandateId = null)
     {
@@ -37,7 +37,7 @@ class Reference
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getEndToEndId()
     {

--- a/src/Camt053/DTO/RelatedParty.php
+++ b/src/Camt053/DTO/RelatedParty.php
@@ -1,5 +1,6 @@
 <?php
-namespace Genkgo\Camt\Camt053;
+
+namespace Genkgo\Camt\Camt053\DTO;
 
 use BadMethodCallException;
 

--- a/src/Camt053/DTO/RelatedPartyTypeInterface.php
+++ b/src/Camt053/DTO/RelatedPartyTypeInterface.php
@@ -1,5 +1,6 @@
 <?php
-namespace Genkgo\Camt\Camt053;
+
+namespace Genkgo\Camt\Camt053\DTO;
 
 /**
  * Interface RelatedPartyTypeInterface

--- a/src/Camt053/DTO/RemittanceInformation.php
+++ b/src/Camt053/DTO/RemittanceInformation.php
@@ -1,5 +1,6 @@
 <?php
-namespace Genkgo\Camt\Camt053;
+
+namespace Genkgo\Camt\Camt053\DTO;
 
 /**
  * Class RemittanceInformation

--- a/src/Camt053/DTO/ReturnInformation.php
+++ b/src/Camt053/DTO/ReturnInformation.php
@@ -1,5 +1,6 @@
 <?php
-namespace Genkgo\Camt\Camt053;
+
+namespace Genkgo\Camt\Camt053\DTO;
 
 /**
  * Class ReturnInformation

--- a/src/Camt053/DTO/Statement.php
+++ b/src/Camt053/DTO/Statement.php
@@ -1,5 +1,6 @@
 <?php
-namespace Genkgo\Camt\Camt053;
+
+namespace Genkgo\Camt\Camt053\DTO;
 
 /**
  * Class Statement

--- a/src/Camt053/Decoder.php
+++ b/src/Camt053/Decoder.php
@@ -5,7 +5,6 @@ use DateTimeImmutable;
 use DOMDocument;
 use Genkgo\Camt\DecoderInterface;
 use Genkgo\Camt\Exception\InvalidMessageException;
-use Genkgo\Camt\Iban;
 use Genkgo\Camt\Util\StringToUnits;
 use Money\Currency;
 use Money\Money;
@@ -19,16 +18,23 @@ class Decoder implements DecoderInterface
     private $document;
 
     /**
+     * @var Decoder\Message
+     */
+    private $messageDecoder;
+
+    /**
      * Path to the schema definition
      * @var string
      */
     protected $schemeDefinitionPath;
 
     /**
-     * @param $schemeDefinitionPath
+     * @param Decoder\Message $messageDecoder
+     * @param string          $schemeDefinitionPath
      */
-    public function __construct($schemeDefinitionPath)
+    public function __construct(Decoder\Message $messageDecoder, $schemeDefinitionPath)
     {
+        $this->messageDecoder       = $messageDecoder;
         $this->schemeDefinitionPath = $schemeDefinitionPath;
     }
 
@@ -64,274 +70,10 @@ class Decoder implements DecoderInterface
         $this->validate($document);
         $this->document = simplexml_import_dom($document);
 
-        $message = new Message();
-        $this->addGroupHeaderToMessage($message);
-        $this->addStatementsToMessage($message);
+        $message = new DTO\Message();
+        $this->messageDecoder->addGroupHeader($message, $this->document);
+        $this->messageDecoder->addStatements($message, $this->document);
 
         return $message;
-    }
-
-    /**
-     * @param SimpleXMLElement $statementXml
-     * @param Statement $statement
-     */
-    private function addBalancesToStatement(SimpleXMLElement $statementXml, Statement $statement)
-    {
-        $balancesXml = $statementXml->Bal;
-        foreach ($balancesXml as $balanceXml) {
-            $amount = StringToUnits::convert((string) $balanceXml->Amt);
-            $currency = (string)$balanceXml->Amt['Ccy'];
-            $date = (string)$balanceXml->Dt->Dt;
-
-            if ((string) $balanceXml->CdtDbtInd === 'DBIT') {
-                $amount = $amount * -1;
-            }
-
-            if ((string) $balanceXml->Tp->CdOrPrtry->Cd === 'OPBD') {
-                $balance = Balance::opening(
-                    new Money(
-                        $amount,
-                        new Currency($currency)
-                    ),
-                    new DateTimeImmutable($date)
-                );
-            } else {
-                $balance = Balance::closing(
-                    new Money(
-                        $amount,
-                        new Currency($currency)
-                    ),
-                    new DateTimeImmutable($date)
-                );
-            }
-
-            $statement->addBalance($balance);
-        }
-    }
-
-    /**
-     * @param SimpleXMLElement $statementXml
-     * @param Statement $statement
-     */
-    private function addEntriesToStatement(SimpleXMLElement $statementXml, Statement $statement)
-    {
-        $index = 0;
-        $entriesXml = $statementXml->Ntry;
-        foreach ($entriesXml as $entryXml) {
-            $amount = StringToUnits::convert((string) $entryXml->Amt);
-            $currency = (string)$entryXml->Amt['Ccy'];
-            $bookingDate = (string)$entryXml->BookgDt->Dt;
-            $valueDate = (string)$entryXml->ValDt->Dt;
-
-            if ((string) $entryXml->CdtDbtInd === 'DBIT') {
-                $amount = $amount * -1;
-            }
-
-            $entry = new Entry(
-                $statement,
-                $index,
-                new Money($amount, new Currency($currency)),
-                new DateTimeImmutable($bookingDate),
-                new DateTimeImmutable($valueDate)
-            );
-
-            if (isset($entryXml->RvslInd) && (string) $entryXml->RvslInd === 'true') {
-                $entry->setReversalIndicator(true);
-            }
-
-            if (isset($entryXml->NtryRef) && (string) $entryXml->NtryRef) {
-                $entry->setReference((string) $entryXml->NtryRef);
-            }
-
-            if (isset($entryXml->AcctSvcrRef) && (string) $entryXml->AcctSvcrRef) {
-                $entry->setAccountServicerReference((string) $entryXml->AcctSvcrRef);
-            }
-
-            if (isset($entryXml->NtryDtls->Btch->PmtInfId) && (string) $entryXml->NtryDtls->Btch->PmtInfId) {
-                $entry->setBatchPaymentId((string) $entryXml->NtryDtls->Btch->PmtInfId);
-            }
-
-            $this->addTransactionDetailsToEntry($entryXml, $entry);
-
-            $statement->addEntry($entry);
-            $index++;
-        }
-    }
-
-    /**
-     * @param SimpleXMLElement $entryXml
-     * @param Entry $entry
-     */
-    private function addTransactionDetailsToEntry(SimpleXMLElement $entryXml, Entry $entry)
-    {
-        $detailsXml = $entryXml->NtryDtls->TxDtls;
-        if ($detailsXml) {
-            foreach ($detailsXml as $detailXml) {
-                $detail = new EntryTransactionDetail();
-                $this->addReferencesToTransactionDetails($detailXml, $detail);
-                $this->addRelatedPartiesToTransactionDetails($detailXml, $detail);
-                $this->addRemittanceInformationToTransactionDetails($detailXml, $detail);
-                $this->addReturnInformationToTransactionDetails($detailXml, $detail);
-                $this->addAdditionalTransactionInformation($detailXml, $detail);
-                $entry->addTransactionDetail($detail);
-            }
-        }
-    }
-
-    /**
-     * @param SimpleXMLElement $detailXml
-     * @param EntryTransactionDetail $detail
-     */
-    private function addRelatedPartiesToTransactionDetails(SimpleXMLElement $detailXml, EntryTransactionDetail $detail)
-    {
-        if (isset($detailXml->RltdPties)) {
-            foreach ($detailXml->RltdPties as $relatedPartyXml) {
-                if (isset($relatedPartyXml->Cdtr)) {
-                    $relatedPartyTypeXml = $relatedPartyXml->Cdtr;
-                    $relatedPartyTypeAccountXml = $relatedPartyXml->CdtrAcct;
-                    $relatedPartyType = $creditor = new Creditor((string) $relatedPartyTypeXml->Nm);
-                } elseif (isset($relatedPartyXml->Dbtr)) {
-                    $relatedPartyTypeXml = $relatedPartyXml->Dbtr;
-                    $relatedPartyTypeAccountXml = $relatedPartyXml->DbtrAcct;
-                    $relatedPartyType = $creditor = new Debtor((string) $relatedPartyTypeXml->Nm);
-                } else {
-                    continue;
-                }
-
-                if (isset($relatedPartyTypeXml->PstlAdr)) {
-                    $address = new Address();
-                    if (isset($relatedPartyTypeXml->PstlAdr->Ctry)) {
-                        $address = $address->setCountry((string) $relatedPartyTypeXml->PstlAdr->Ctry);
-                    }
-                    if (isset($relatedPartyTypeXml->PstlAdr->AdrLine)) {
-                        foreach ($relatedPartyTypeXml->PstlAdr->AdrLine as $line) {
-                            $address = $address->addAddressLine((string)$line);
-                        }
-                    }
-
-                    $relatedPartyType->setAddress($address);
-                }
-
-                if (isset($relatedPartyTypeAccountXml->Id->IBAN) && $ibanCode = (string) $relatedPartyTypeAccountXml->Id->IBAN) {
-                    $account = new Account(new Iban($ibanCode));
-                } else {
-                    $account = null;
-                }
-
-                $relatedParty = new RelatedParty($relatedPartyType, $account);
-                $detail->addRelatedParty($relatedParty);
-            }
-        }
-    }
-
-    /**
-     * @param SimpleXMLElement $detailXml
-     * @param EntryTransactionDetail $detail
-     */
-    private function addReferencesToTransactionDetails(SimpleXMLElement $detailXml, EntryTransactionDetail $detail)
-    {
-        if (isset($detailXml->Refs->EndToEndId)) {
-            $endToEndId = (string)$detailXml->Refs->EndToEndId;
-            if (isset($detailXml->Refs->MndtId)) {
-                $mandateId = (string)$detailXml->Refs->MndtId;
-            } else {
-                $mandateId = null;
-            }
-            $detail->addReference(new Reference($endToEndId, $mandateId));
-        }
-    }
-
-    /**
-     * @param SimpleXMLElement $detailXml
-     * @param EntryTransactionDetail $detail
-     */
-    private function addRemittanceInformationToTransactionDetails(SimpleXMLElement $detailXml, EntryTransactionDetail $detail)
-    {
-        if (isset($detailXml->RmtInf)) {
-            if (isset($detailXml->RmtInf->Ustrd)) {
-                $remittanceInformation = RemittanceInformation::fromUnstructured(
-                    (string)$detailXml->RmtInf->Ustrd
-                );
-                $detail->setRemittanceInformation($remittanceInformation);
-            } elseif (isset($detailXml->RmtInf->Strd)) {
-                if (isset($detailXml->RmtInf->Strd->CdtrRefInf) && isset($detailXml->RmtInf->Strd->CdtrRefInf->Ref)) {
-                    $creditorReferenceInformation = CreditorReferenceInformation::fromUnstructured(
-                        (string)$detailXml->RmtInf->Strd->CdtrRefInf->Ref
-                    );
-                    $remittanceInformation = new RemittanceInformation();
-                    $remittanceInformation->setCreditorReferenceInformation($creditorReferenceInformation);
-                    $detail->setRemittanceInformation($remittanceInformation);
-                }
-            }
-        }
-    }
-
-    /**
-     * @param SimpleXMLElement $detailXml
-     * @param EntryTransactionDetail $detail
-     */
-    private function addReturnInformationToTransactionDetails(SimpleXMLElement $detailXml, EntryTransactionDetail $detail)
-    {
-        if (isset($detailXml->RtrInf)) {
-            if (isset($detailXml->RtrInf->Rsn->Cd)) {
-                $remittanceInformation = ReturnInformation::fromUnstructured(
-                    (string)$detailXml->RtrInf->Rsn->Cd,
-                    (string)$detailXml->RtrInf->AddtlInf
-                );
-                $detail->setReturnInformation($remittanceInformation);
-            }
-        }
-    }
-
-    /**
-     * @param Message $message
-     */
-    private function addGroupHeaderToMessage(Message $message)
-    {
-        $groupHeaderXml = $this->document->BkToCstmrStmt->GrpHdr;
-        $groupHeader = new GroupHeader(
-            (string)$groupHeaderXml->MsgId,
-            new DateTimeImmutable((string)$groupHeaderXml->CreDtTm)
-        );
-
-        $message->setGroupHeader($groupHeader);
-    }
-
-    /**
-     * @param Message $message
-     */
-    private function addStatementsToMessage(Message $message)
-    {
-        $statements = [];
-
-        $statementsXml = $this->document->BkToCstmrStmt->Stmt;
-        foreach ($statementsXml as $statementXml) {
-            $statement = new Statement(
-                (string) $statementXml->Id,
-                new DateTimeImmutable((string)$statementXml->CreDtTm),
-                new Account(new Iban((string)$statementXml->Acct->Id->IBAN))
-            );
-
-            $this->addBalancesToStatement($statementXml, $statement);
-            $this->addEntriesToStatement($statementXml, $statement);
-
-            $statements[] = $statement;
-        }
-
-        $message->setStatements($statements);
-    }
-
-    /**
-     * @param SimpleXMLElement $detailXml
-     * @param EntryTransactionDetail $detail
-     */
-    private function addAdditionalTransactionInformation(SimpleXMLElement $detailXml, EntryTransactionDetail $detail)
-    {
-        if (isset($detailXml->AddtlTxInf)) {
-            $additionalInformation = new AdditionalTransactionInformation(
-                (string) $detailXml->AddtlTxInf
-            );
-            $detail->setAdditionalTransactionInformation($additionalInformation);
-        }
     }
 }

--- a/src/Camt053/Decoder/Entry.php
+++ b/src/Camt053/Decoder/Entry.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Genkgo\Camt\Camt053\Decoder;
+
+use Genkgo\Camt\Camt053\DTO;
+use \SimpleXMLElement;
+
+class Entry
+{
+    /**
+     * @var EntryTransactionDetail
+     */
+    private $entryTransactionDetailDecoder;
+
+    public function __construct(EntryTransactionDetail $entryTransactionDetailDecoder)
+    {
+        $this->entryTransactionDetailDecoder = $entryTransactionDetailDecoder;
+    }
+
+    /**
+     * @param DTO\Entry        $entry
+     * @param SimpleXMLElement $xmlEntry
+     */
+    public function addTransactionDetails(DTO\Entry $entry, SimpleXMLElement $xmlEntry)
+    {
+        $xmlDetails = $xmlEntry->NtryDtls->TxDtls;
+
+        if ($xmlDetails) {
+            foreach ($xmlDetails as $xmlDetail) {
+                $detail = new DTO\EntryTransactionDetail();
+                $this->entryTransactionDetailDecoder->addReferences($detail, $xmlDetail);
+                $this->entryTransactionDetailDecoder->addRelatedParties($detail, $xmlDetail);
+                $this->entryTransactionDetailDecoder->addRemittanceInformation($detail, $xmlDetail);
+                $this->entryTransactionDetailDecoder->addReturnInformation($detail, $xmlDetail);
+                $this->entryTransactionDetailDecoder->addAdditionalTransactionInformation($detail, $xmlDetail);
+
+                $entry->addTransactionDetail($detail);
+            }
+        }
+    }
+}

--- a/src/Camt053/Decoder/EntryTransactionDetail.php
+++ b/src/Camt053/Decoder/EntryTransactionDetail.php
@@ -90,15 +90,20 @@ class EntryTransactionDetail
                 (string)$xmlDetail->RmtInf->Ustrd
             );
             $detail->setRemittanceInformation($remittanceInformation);
-        } elseif (isset($xmlDetail->RmtInf->Strd)) {
-            if (isset($xmlDetail->RmtInf->Strd->CdtrRefInf) && isset($xmlDetail->RmtInf->Strd->CdtrRefInf->Ref)) {
-                $creditorReferenceInformation = DTO\CreditorReferenceInformation::fromUnstructured(
-                    (string)$xmlDetail->RmtInf->Strd->CdtrRefInf->Ref
-                );
-                $remittanceInformation = new DTO\RemittanceInformation();
-                $remittanceInformation->setCreditorReferenceInformation($creditorReferenceInformation);
-                $detail->setRemittanceInformation($remittanceInformation);
-            }
+
+            return;
+        }
+        
+        if (isset($xmlDetail->RmtInf->Strd)
+            && isset($xmlDetail->RmtInf->Strd->CdtrRefInf)
+            && isset($xmlDetail->RmtInf->Strd->CdtrRefInf->Ref)
+        ) {
+            $creditorReferenceInformation = DTO\CreditorReferenceInformation::fromUnstructured(
+                (string)$xmlDetail->RmtInf->Strd->CdtrRefInf->Ref
+            );
+            $remittanceInformation = new DTO\RemittanceInformation();
+            $remittanceInformation->setCreditorReferenceInformation($creditorReferenceInformation);
+            $detail->setRemittanceInformation($remittanceInformation);
         }
     }
 

--- a/src/Camt053/Decoder/EntryTransactionDetail.php
+++ b/src/Camt053/Decoder/EntryTransactionDetail.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Genkgo\Camt\Camt053\Decoder;
+
+use Genkgo\Camt\Camt053\DTO;
+use \SimpleXMLElement;
+use Genkgo\Camt\Iban;
+
+class EntryTransactionDetail
+{
+    /**
+     * @param DTO\EntryTransactionDetail $detail
+     * @param SimpleXMLElement           $xmlDetail
+     */
+    public function addReferences(DTO\EntryTransactionDetail $detail, SimpleXMLElement $xmlDetail)
+    {
+        if (false === isset($xmlDetail->Refs->EndToEndId)) {
+            return;
+        }
+
+        $endToEndId = (string)$xmlDetail->Refs->EndToEndId;
+        $mandateId = null;
+
+        if (isset($xmlDetail->Refs->MndtId)) {
+            $mandateId = (string)$xmlDetail->Refs->MndtId;
+        }
+
+        $detail->addReference(new DTO\Reference($endToEndId, $mandateId));
+    }
+
+    /**
+     * @param DTO\EntryTransactionDetail $detail
+     * @param SimpleXMLElement           $xmlDetail
+     */
+    public function addRelatedParties(DTO\EntryTransactionDetail $detail, SimpleXMLElement $xmlDetail)
+    {
+        if (false === isset($xmlDetail->RltdPties)) {
+            return;
+        }
+
+        foreach ($xmlDetail->RltdPties as $xmlRelatedParty) {
+            if (isset($xmlRelatedParty->Cdtr)) {
+                $xmlRelatedPartyType = $xmlRelatedParty->Cdtr;
+                $xmlRelatedPartyTypeAccount = $xmlRelatedParty->CdtrAcct;
+                $relatedPartyType = $creditor = new DTO\Creditor((string) $xmlRelatedPartyType->Nm);
+            } elseif (isset($xmlRelatedParty->Dbtr)) {
+                $xmlRelatedPartyType = $xmlRelatedParty->Dbtr;
+                $xmlRelatedPartyTypeAccount = $xmlRelatedParty->DbtrAcct;
+                $relatedPartyType = $creditor = new DTO\Debtor((string) $xmlRelatedPartyType->Nm);
+            } else {
+                continue;
+            }
+
+            if (isset($xmlRelatedPartyType->PstlAdr)) {
+                $address = new DTO\Address();
+                if (isset($xmlRelatedPartyType->PstlAdr->Ctry)) {
+                    $address = $address->setCountry((string) $xmlRelatedPartyType->PstlAdr->Ctry);
+                }
+                if (isset($xmlRelatedPartyType->PstlAdr->AdrLine)) {
+                    foreach ($xmlRelatedPartyType->PstlAdr->AdrLine as $line) {
+                        $address = $address->addAddressLine((string)$line);
+                    }
+                }
+
+                $relatedPartyType->setAddress($address);
+            }
+
+            $acount = null;
+            if (isset($xmlRelatedPartyTypeAccount->Id->IBAN) && $ibanCode = (string) $xmlRelatedPartyTypeAccount->Id->IBAN) {
+                $account = new DTO\Account(new Iban($ibanCode));
+            }
+
+            $relatedParty = new DTO\RelatedParty($relatedPartyType, $account);
+            $detail->addRelatedParty($relatedParty);
+        }
+    }
+
+    /**
+     * @param DTO\EntryTransactionDetail $detail
+     * @param SimpleXMLElement           $xmlDetail
+     */
+    public function addRemittanceInformation(DTO\EntryTransactionDetail $detail, SimpleXMLElement $xmlDetail)
+    {
+        if (false === isset($xmlDetail->RmtInf)) {
+            return;
+        }
+
+        if (isset($xmlDetail->RmtInf->Ustrd)) {
+            $remittanceInformation = DTO\RemittanceInformation::fromUnstructured(
+                (string)$xmlDetail->RmtInf->Ustrd
+            );
+            $detail->setRemittanceInformation($remittanceInformation);
+        } elseif (isset($xmlDetail->RmtInf->Strd)) {
+            if (isset($xmlDetail->RmtInf->Strd->CdtrRefInf) && isset($xmlDetail->RmtInf->Strd->CdtrRefInf->Ref)) {
+                $creditorReferenceInformation = DTO\CreditorReferenceInformation::fromUnstructured(
+                    (string)$xmlDetail->RmtInf->Strd->CdtrRefInf->Ref
+                );
+                $remittanceInformation = new DTO\RemittanceInformation();
+                $remittanceInformation->setCreditorReferenceInformation($creditorReferenceInformation);
+                $detail->setRemittanceInformation($remittanceInformation);
+            }
+        }
+    }
+
+    /**
+     * @param DTO\EntryTransactionDetail $detail
+     * @param SimpleXMLElement           $xmlDetail
+     */
+    public function addReturnInformation(DTO\EntryTransactionDetail $detail, SimpleXMLElement $xmlDetail)
+    {
+        if (isset($xmlDetail->RtrInf) && isset($xmlDetail->RtrInf->Rsn->Cd)) {
+            $remittanceInformation = DTO\ReturnInformation::fromUnstructured(
+                (string)$xmlDetail->RtrInf->Rsn->Cd,
+                (string)$xmlDetail->RtrInf->AddtlInf
+            );
+            $detail->setReturnInformation($remittanceInformation);
+        }
+    }
+
+    /**
+     * @param DTO\EntryTransactionDetail $detail
+     * @param SimpleXMLElement           $xmlDetail
+     */
+    public function addAdditionalTransactionInformation(DTO\EntryTransactionDetail $detail, SimpleXMLElement $xmlDetail)
+    {
+        if (isset($xmlDetail->AddtlTxInf)) {
+            $additionalInformation = new DTO\AdditionalTransactionInformation(
+                (string) $xmlDetail->AddtlTxInf
+            );
+            $detail->setAdditionalTransactionInformation($additionalInformation);
+        }
+    }
+}

--- a/src/Camt053/Decoder/Message.php
+++ b/src/Camt053/Decoder/Message.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Genkgo\Camt\Camt053\Decoder;
+
+use Genkgo\Camt\Camt053\DTO;
+use DateTimeImmutable;
+use SimpleXMLElement;
+use Genkgo\Camt\Iban;
+
+class Message
+{
+    /**
+     * @var Statement
+     */
+    private $statementDecoder;
+
+    public function __construct(Statement $statementDecoder)
+    {
+        $this->statementDecoder = $statementDecoder;
+    }
+
+    /**
+     * @param DTO\Message      $message
+     * @param SimpleXMLElement $document
+     */
+    public function addGroupHeader(DTO\Message $message, SimpleXMLElement $document)
+    {
+        $xmlGroupHeader = $document->BkToCstmrStmt->GrpHdr;
+        $groupHeader = new DTO\GroupHeader(
+            (string)$xmlGroupHeader->MsgId,
+            new DateTimeImmutable((string)$xmlGroupHeader->CreDtTm)
+        );
+
+        $message->setGroupHeader($groupHeader);
+    }
+
+    /**
+     * @param DTO\Message      $message
+     * @param SimpleXMLElement $document
+     */
+    public function addStatements(DTO\Message $message, SimpleXMLElement $document)
+    {
+        $statements = [];
+
+        $xmlStatements = $document->BkToCstmrStmt->Stmt;
+        foreach ($xmlStatements as $xmlStatement) {
+            $statement = new DTO\Statement(
+                (string) $xmlStatement->Id,
+                new DateTimeImmutable((string)$xmlStatement->CreDtTm),
+                new DTO\Account(new Iban((string)$xmlStatement->Acct->Id->IBAN))
+            );
+
+            $this->statementDecoder->addBalances($statement, $xmlStatement);
+            $this->statementDecoder->addEntries($statement, $xmlStatement);
+
+            $statements[] = $statement;
+        }
+
+        $message->setStatements($statements);
+    }
+}

--- a/src/Camt053/Decoder/Statement.php
+++ b/src/Camt053/Decoder/Statement.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Genkgo\Camt\Camt053\Decoder;
+
+use Genkgo\Camt\Camt053\DTO;
+use Genkgo\Camt\Util\StringToUnits;
+use Money\Money;
+use Money\Currency;
+use \SimpleXMLElement;
+use \DateTimeImmutable;
+
+class Statement
+{
+    /**
+     * @var Entry
+     */
+    private $entryDecoder;
+
+    public function __construct(Entry $entryDecoder)
+    {
+        $this->entryDecoder = $entryDecoder;
+    }
+
+    /**
+     * @param DTO\Statement    $statement
+     * @param SimpleXMLElement $xmlStatement
+     */
+    public function addBalances(DTO\Statement $statement, SimpleXMLElement $xmlStatement)
+    {
+        $xmlBalances = $xmlStatement->Bal;
+        foreach ($xmlBalances as $xmlBalance) {
+            $amount = StringToUnits::convert((string) $xmlBalance->Amt);
+            $currency = (string)$xmlBalance->Amt['Ccy'];
+            $date = (string)$xmlBalance->Dt->Dt;
+
+            if ((string) $xmlBalance->CdtDbtInd === 'DBIT') {
+                $amount = $amount * -1;
+            }
+
+            if ((string) $xmlBalance->Tp->CdOrPrtry->Cd === 'OPBD') {
+                $balance = DTO\Balance::opening(
+                    new Money(
+                        $amount,
+                        new Currency($currency)
+                    ),
+                    new DateTimeImmutable($date)
+                );
+            } else {
+                $balance = DTO\Balance::closing(
+                    new Money(
+                        $amount,
+                        new Currency($currency)
+                    ),
+                    new DateTimeImmutable($date)
+                );
+            }
+
+            $statement->addBalance($balance);
+        }
+    }
+
+    /**
+     * @param DTO\Statement    $statement
+     * @param SimpleXMLElement $xmlStatement
+     */
+    public function addEntries(DTO\Statement $statement, SimpleXMLElement $xmlStatement)
+    {
+        $index = 0;
+        $xmlEntries = $xmlStatement->Ntry;
+        foreach ($xmlEntries as $xmlEntry) {
+            $amount = StringToUnits::convert((string) $xmlEntry->Amt);
+            $currency = (string)$xmlEntry->Amt['Ccy'];
+            $bookingDate = (string)$xmlEntry->BookgDt->Dt;
+            $valueDate = (string)$xmlEntry->ValDt->Dt;
+
+            if ((string) $xmlEntry->CdtDbtInd === 'DBIT') {
+                $amount = $amount * -1;
+            }
+
+            $entry = new DTO\Entry(
+                $statement,
+                $index,
+                new Money($amount, new Currency($currency)),
+                new DateTimeImmutable($bookingDate),
+                new DateTimeImmutable($valueDate)
+            );
+
+            if (isset($xmlEntry->RvslInd) && (string) $xmlEntry->RvslInd === 'true') {
+                $entry->setReversalIndicator(true);
+            }
+
+            if (isset($xmlEntry->NtryRef) && (string) $xmlEntry->NtryRef) {
+                $entry->setReference((string) $xmlEntry->NtryRef);
+            }
+
+            if (isset($xmlEntry->AcctSvcrRef) && (string) $xmlEntry->AcctSvcrRef) {
+                $entry->setAccountServicerReference((string) $xmlEntry->AcctSvcrRef);
+            }
+
+            if (isset($xmlEntry->NtryDtls->Btch->PmtInfId) && (string) $xmlEntry->NtryDtls->Btch->PmtInfId) {
+                $entry->setBatchPaymentId((string) $xmlEntry->NtryDtls->Btch->PmtInfId);
+            }
+
+            $this->entryDecoder->addTransactionDetails($entry, $xmlEntry);
+
+            $statement->addEntry($entry);
+            $index++;
+        }
+    }
+}

--- a/src/Camt053/Decoder/Statement.php
+++ b/src/Camt053/Decoder/Statement.php
@@ -37,7 +37,10 @@ class Statement
                 $amount = $amount * -1;
             }
 
-            if ((string) $xmlBalance->Tp->CdOrPrtry->Cd === 'OPBD') {
+            if (isset($xmlBalance->Tp)
+                && isset($xmlBalance->Tp->CdOrPrtry)
+                && (string) $xmlBalance->Tp->CdOrPrtry->Cd === 'OPBD'
+            ) {
                 $balance = DTO\Balance::opening(
                     new Money(
                         $amount,

--- a/src/Camt053/Iterator/EntryIterator.php
+++ b/src/Camt053/Iterator/EntryIterator.php
@@ -3,7 +3,7 @@ namespace Genkgo\Camt\Camt053\Iterator;
 
 use AppendIterator;
 use ArrayIterator;
-use Genkgo\Camt\Camt053\Message;
+use Genkgo\Camt\Camt053\DTO;
 
 /**
  * Class SimpleEntryIterator
@@ -14,7 +14,7 @@ class EntryIterator extends \IteratorIterator
     /**
      * @param Message $message
      */
-    public function __construct(Message $message)
+    public function __construct(DTO\Message $message)
     {
         $appendIterator = new AppendIterator();
         $statements = $message->getStatements();

--- a/src/Camt053/MessageFormat/Camt053V02.php
+++ b/src/Camt053/MessageFormat/Camt053V02.php
@@ -1,5 +1,6 @@
 <?php
-namespace Genkgo\Camt\Camt053\Message;
+
+namespace Genkgo\Camt\Camt053\MessageFormat;
 
 use Genkgo\Camt\Camt053\Decoder;
 use Genkgo\Camt\DecoderInterface;
@@ -40,6 +41,11 @@ final class Camt053V02 implements MessageFormatInterface
      */
     public function getDecoder()
     {
-        return new Decoder('/assets/camt.053.001.02.xsd');
+        $entryTransactionDetailDecoder = new Decoder\EntryTransactionDetail();
+        $entryDecoder                  = new Decoder\Entry($entryTransactionDetailDecoder);
+        $statementDecoder              = new Decoder\Statement($entryDecoder);
+        $messageDecoder                = new Decoder\Message($statementDecoder);
+
+        return new Decoder($messageDecoder, '/assets/camt.053.001.02.xsd');
     }
 }

--- a/src/Camt053/MessageFormat/Camt053V03.php
+++ b/src/Camt053/MessageFormat/Camt053V03.php
@@ -1,5 +1,6 @@
 <?php
-namespace Genkgo\Camt\Camt053\Message;
+
+namespace Genkgo\Camt\Camt053\MessageFormat;
 
 use Genkgo\Camt\Camt053\Decoder;
 use Genkgo\Camt\DecoderInterface;
@@ -40,6 +41,11 @@ final class Camt053V03 implements MessageFormatInterface
      */
     public function getDecoder()
     {
-        return new Decoder('/assets/camt.053.001.03.xsd');
+        $entryTransactionDetailDecoder = new Decoder\EntryTransactionDetail();
+        $entryDecoder                  = new Decoder\Entry($entryTransactionDetailDecoder);
+        $statementDecoder              = new Decoder\Statement($entryDecoder);
+        $messageDecoder                = new Decoder\Message($statementDecoder);
+
+        return new Decoder($messageDecoder, '/assets/camt.053.001.03.xsd');
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -1,8 +1,9 @@
 <?php
+
 namespace Genkgo\Camt;
 
-use Genkgo\Camt\Camt053\Message\Camt053V02;
-use Genkgo\Camt\Camt053\Message\Camt053V03;
+use Genkgo\Camt\Camt053\MessageFormat\Camt053V02;
+use Genkgo\Camt\Camt053\MessageFormat\Camt053V03;
 
 /**
  * Class Config

--- a/tests/Unit/Camt053/Decoder/EntryTest.php
+++ b/tests/Unit/Camt053/Decoder/EntryTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Genkgo\Camt\Unit\Camt053\Decoder;
+
+use Genkgo\Camt\AbstractTestCase;
+use Genkgo\Camt\Camt053\Decoder;
+use Genkgo\Camt\Camt053\DTO;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+
+class EntryTest extends AbstractTestCase
+{
+    /** @var ObjectProphecy */
+    private $mockedEntryTransactionDetailDecoder;
+
+    /** @var Decoder\Entry */
+    private $decoder;
+
+    public function setUp()
+    {
+        $this->mockedEntryTransactionDetailDecoder = $this->prophesize(Decoder\EntryTransactionDetail::class);
+        $this->decoder = new Decoder\Entry($this->mockedEntryTransactionDetailDecoder->reveal());
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_add_transaction_details_if_there_is_none_in_xml()
+    {
+        $entry = $this->prophesize(DTO\Entry::class);
+        $entry->addTransactionDetail(Argument::any())->shouldNotBeCalled();
+
+        $xmlEntry = new \SimpleXMLElement('<content></content>');
+        $this->decoder->addTransactionDetails($entry->reveal(), $xmlEntry);
+    }
+
+    /**
+     * @test
+     */
+    public function it_adds_transaction_details_if_there_are_present_in_xml()
+    {
+        $entry = $this->prophesize(DTO\Entry::class);
+        $this->mockedEntryTransactionDetailDecoder->addReferences(
+            Argument::type(DTO\EntryTransactionDetail::class),
+            Argument::type('\SimpleXMLElement')
+        )->shouldBeCalled();
+        $this->mockedEntryTransactionDetailDecoder->addRelatedParties(
+            Argument::type(DTO\EntryTransactionDetail::class),
+            Argument::type('\SimpleXMLElement')
+        )->shouldBeCalled();
+        $this->mockedEntryTransactionDetailDecoder->addRemittanceInformation(
+            Argument::type(DTO\EntryTransactionDetail::class),
+            Argument::type('\SimpleXMLElement')
+        )->shouldBeCalled();
+        $this->mockedEntryTransactionDetailDecoder->addReturnInformation(
+            Argument::type(DTO\EntryTransactionDetail::class),
+            Argument::type('\SimpleXMLElement')
+        )->shouldBeCalled();
+        $this->mockedEntryTransactionDetailDecoder->addAdditionalTransactionInformation(
+            Argument::type(DTO\EntryTransactionDetail::class),
+            Argument::type('\SimpleXMLElement')
+        )->shouldBeCalled();
+        $entry->addTransactionDetail(Argument::type(DTO\EntryTransactionDetail::class))->shouldBeCalled();
+
+        $this->decoder->addTransactionDetails($entry->reveal(), $this->getXmlEntry());
+    }
+
+    private function getXmlEntry()
+    {
+        $xmlContent = <<<XML
+<content>
+    <NtryDtls>
+        <TxDtls>
+            <EndToEndId>000000001</EndToEndId>
+        </TxDtls>
+    </NtryDtls>
+</content>
+XML;
+
+        return new \SimpleXMLElement($xmlContent);
+    }
+}

--- a/tests/Unit/Camt053/Decoder/EntryTransactionDetailTest.php
+++ b/tests/Unit/Camt053/Decoder/EntryTransactionDetailTest.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace Genkgo\Camt\Unit\Camt053\Decoder;
+
+use Genkgo\Camt\AbstractTestCase;
+use Genkgo\Camt\Camt053\Decoder;
+use Genkgo\Camt\Camt053\DTO;
+use Prophecy\Argument;
+
+class EntryTransactionDetailTest extends AbstractTestCase
+{
+    /**
+     * @test
+     */
+    public function it_does_not_add_reference_if_there_is_none_in_xml()
+    {
+        $detail = $this->prophesize(DTO\EntryTransactionDetail::class);
+        $detail->addReference(Argument::any())->shouldNotBeCalled();
+
+        $xmlDetail = new \SimpleXMLElement('<content></content>');
+        (new Decoder\EntryTransactionDetail())->addReferences($detail->reveal(), $xmlDetail);
+    }
+
+    /**
+     * @test
+     */
+    public function it_adds_reference_if_it_is_present_in_xml()
+    {
+        $detail = $this->prophesize(DTO\EntryTransactionDetail::class);
+        $detail->addReference(Argument::type(DTO\Reference::class))->shouldBeCalled();
+
+        (new Decoder\EntryTransactionDetail())->addReferences($detail->reveal(), $this->getXmlDetail());
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_add_additional_transaction_information_if_there_is_none_in_xml()
+    {
+        $detail = $this->prophesize(DTO\EntryTransactionDetail::class);
+        $detail->setAdditionalTransactionInformation(Argument::any())->shouldNotBeCalled();
+
+        $xmlDetail = new \SimpleXMLElement('<content></content>');
+        (new Decoder\EntryTransactionDetail())->addAdditionalTransactionInformation($detail->reveal(), $xmlDetail);
+    }
+
+    /**
+     * @test
+     */
+    public function it_adds_additional_transaction_information_if_it_is_present_in_xml()
+    {
+        $detail = $this->prophesize(DTO\EntryTransactionDetail::class);
+        $detail->setAdditionalTransactionInformation(
+            Argument::type(DTO\AdditionalTransactionInformation::class)
+        )->shouldBeCalled();
+
+        (new Decoder\EntryTransactionDetail())->addAdditionalTransactionInformation($detail->reveal(), $this->getXmlDetail());
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_add_remittance_information_if_there_is_none_in_xml()
+    {
+        $detail = $this->prophesize(DTO\EntryTransactionDetail::class);
+        $detail->setRemittanceInformation(Argument::any())->shouldNotBeCalled();
+
+        $xmlDetail = new \SimpleXMLElement('<content></content>');
+        (new Decoder\EntryTransactionDetail())->addRemittanceInformation($detail->reveal(), $xmlDetail);
+    }
+
+    /**
+     * @test
+     */
+    public function it_adds_remittance_information_and_creditor_reference_if_it_is_present_in_xml()
+    {
+        $detail = $this->prophesize(DTO\EntryTransactionDetail::class);
+        $detail->setRemittanceInformation(Argument::type(DTO\RemittanceInformation::class))->shouldBeCalled();
+
+        (new Decoder\EntryTransactionDetail())->addRemittanceInformation($detail->reveal(), $this->getXmlDetail());
+    }
+
+    /**
+     * @test
+     */
+    public function it_adds_remittance_information_if_it_is_present_in_xml()
+    {
+        $detail = $this->prophesize(DTO\EntryTransactionDetail::class);
+        $detail->setRemittanceInformation(Argument::type(DTO\RemittanceInformation::class))->shouldBeCalled();
+
+        $xmlDetail = new \SimpleXMLElement('<content><RmtInf><Ustrd>Lorem</Ustrd></RmtInf></content>');
+        (new Decoder\EntryTransactionDetail())->addRemittanceInformation($detail->reveal(), $xmlDetail);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_add_return_information_if_there_is_none_in_xml()
+    {
+        $detail = $this->prophesize(DTO\EntryTransactionDetail::class);
+        $detail->setReturnInformation(Argument::any())->shouldNotBeCalled();
+
+        $xmlDetail = new \SimpleXMLElement('<content></content>');
+        (new Decoder\EntryTransactionDetail())->addReturnInformation($detail->reveal(), $xmlDetail);
+    }
+
+    /**
+     * @test
+     */
+    public function it_adds_return_information_if_it_is_present_in_xml()
+    {
+        $detail = $this->prophesize(DTO\EntryTransactionDetail::class);
+        $detail->setReturnInformation(
+            Argument::type(DTO\ReturnInformation::class)
+        )->shouldBeCalled();
+
+        (new Decoder\EntryTransactionDetail())->addReturnInformation($detail->reveal(), $this->getXmlDetail());
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_add_related_parties_if_there_is_none_in_xml()
+    {
+        $detail = $this->prophesize(DTO\EntryTransactionDetail::class);
+        $detail->addRelatedParty(Argument::any())->shouldNotBeCalled();
+
+        $xmlDetail = new \SimpleXMLElement('<content></content>');
+        (new Decoder\EntryTransactionDetail())->addRelatedParties($detail->reveal(), $xmlDetail);
+    }
+
+    /**
+     * @test
+     */
+    public function it_adds_related_parties_if_is_present_in_xml()
+    {
+        $detail = $this->prophesize(DTO\EntryTransactionDetail::class);
+        $detail->addRelatedParty(Argument::type(DTO\RelatedParty::class))->shouldBeCalled();
+
+        (new Decoder\EntryTransactionDetail())->addRelatedParties($detail->reveal(), $this->getXmlDetail());
+    }
+
+    private function getXmlDetail()
+    {
+        $xmlContent = <<<XML
+<content>
+    <Refs>
+        <EndToEndId>some end to end id</EndToEndId>
+        <MndtId>some mandate id</MndtId>
+    </Refs>
+    <AddtlTxInf>additional transaction information</AddtlTxInf>
+    <RtrInf>
+        <Rsn>
+            <Cd>lorem</Cd>
+        </Rsn>
+        <AddtlInf>ipsum</AddtlInf>
+    </RtrInf>
+    <RmtInf>
+        <Strd>
+            <CdtrRefInf>
+                <Ref>Some reference</Ref>
+            </CdtrRefInf>
+            <Cd>lorem</Cd>
+        </Strd>
+    </RmtInf>
+    <RltdPties>
+        <Cdtr>
+            <Nm>Lorem</Nm>
+            <PstlAdr>
+                <Ctry>NL</Ctry>
+                <AdrLine>NL</AdrLine>
+            </PstlAdr>
+        </Cdtr>
+        <CdtrAcct>
+            <Id>
+                <IBAN>NL39ULSS6234823955</IBAN>
+            </Id>
+        </CdtrAcct>
+    </RltdPties>
+</content>
+XML;
+
+        return new \SimpleXMLElement($xmlContent);
+    }
+}

--- a/tests/Unit/Camt053/Decoder/MessageTest.php
+++ b/tests/Unit/Camt053/Decoder/MessageTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Genkgo\Camt\Unit\Camt053\Decoder;
+
+use Genkgo\Camt\AbstractTestCase;
+use Genkgo\Camt\Camt053\Decoder;
+use Genkgo\Camt\Camt053\DTO;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+
+class MessageTest extends AbstractTestCase
+{
+    /** @var ObjectProphecy */
+    private $mockedStatementDecoder;
+
+    /** @var Decoder\Message */
+    private $decoder;
+
+    public function setUp()
+    {
+        $entry = $this->prophesize(Decoder\Entry::class);
+        $this->mockedStatementDecoder = $this
+            ->prophesize(Decoder\Statement::class)
+            ->willBeConstructedWith([$entry->reveal()])
+        ;
+        $this->decoder = new Decoder\Message($this->mockedStatementDecoder->reveal());
+    }
+
+    /**
+     * @test
+     */
+    public function it_adds_group_header()
+    {
+        $message = $this->prophesize(DTO\Message::class);
+        $message->setGroupHeader(Argument::type(DTO\GroupHeader::class))->shouldBeCalled();
+
+        $this->decoder->addGroupHeader($message->reveal(), $this->getXmlMessage());
+    }
+
+    /**
+     * @test
+     */
+    public function it_adds_statements()
+    {
+        $message = $this->prophesize(DTO\Message::class);
+
+        $this->mockedStatementDecoder->addBalances(
+            Argument::type(DTO\Statement::class),
+            Argument::type('\SimpleXMLElement')
+        )->shouldBeCalled();
+        $this->mockedStatementDecoder->addEntries(
+            Argument::type(DTO\Statement::class),
+            Argument::type('\SimpleXMLElement')
+        )->shouldBeCalled();
+
+        $message->setStatements(Argument::that(function ($argument) {
+            return is_array($argument) && $argument[0] instanceof DTO\Statement;
+        }))->shouldBeCalled();
+
+        $this->decoder->addStatements($message->reveal(), $this->getXmlMessage());
+    }
+
+    private function getXmlMessage()
+    {
+        $xmlContent = <<<XML
+<content>
+    <BkToCstmrStmt>
+        <GrpHdr>
+            <MsgId>CAMT053RIB000000000001</MsgId>
+            <CreDtTm>2015-03-10T18:43:50+00:00</CreDtTm>
+        </GrpHdr>
+        <Stmt>
+            <Id>253EURNL26VAYB8060476890</Id>
+            <CreDtTm>2015-03-10T18:43:50+00:00</CreDtTm>
+            <Acct>
+                <Id>
+                    <IBAN>NL26VAYB8060476890</IBAN>
+                </Id>
+            </Acct>
+        </Stmt>
+    </BkToCstmrStmt>
+</content>
+
+XML;
+
+        return new \SimpleXMLElement($xmlContent);
+    }
+}

--- a/tests/Unit/Camt053/Decoder/StatementTest.php
+++ b/tests/Unit/Camt053/Decoder/StatementTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Genkgo\Camt\Unit\Camt053\Decoder;
+
+use Genkgo\Camt\AbstractTestCase;
+use Genkgo\Camt\Camt053\Decoder;
+use Genkgo\Camt\Camt053\DTO;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+
+class StatementTest extends AbstractTestCase
+{
+    /** @var ObjectProphecy */
+    private $mockedEntryDecoder;
+
+    /** @var Decoder\Statement */
+    private $decoder;
+
+    public function setUp()
+    {
+        $entryTransactionDetail = $this->prophesize(Decoder\EntryTransactionDetail::class);
+        $this->mockedEntryDecoder = $this
+            ->prophesize(Decoder\Entry::class)
+            ->willBeConstructedWith([$entryTransactionDetail->reveal()])
+        ;
+        $this->decoder = new Decoder\Statement($this->mockedEntryDecoder->reveal());
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_add_balances_if_there_are_none_in_xml()
+    {
+        $statement = $this->prophesize(DTO\Statement::class);
+        $statement->addBalance(Argument::any())->shouldNotBeCalled();
+
+        $xmlStatement = new \SimpleXMLElement('<content></content>');
+        $this->decoder->addBalances($statement->reveal(), $xmlStatement);
+    }
+
+    /**
+     * @test
+     */
+    public function it_adds_balances_if_there_are_present_in_xml()
+    {
+        $statement = $this->prophesize(DTO\Statement::class);
+        $statement->addBalance(Argument::type(DTO\Balance::class))->shouldBeCalled();
+
+        $this->decoder->addBalances($statement->reveal(), $this->getXmlStatement());
+    }
+
+    /**
+     * @test
+     */
+    public function it_adds_no_entries_if_there_are_none_in_xml()
+    {
+        $statement = $this->prophesize(DTO\Statement::class);
+        $this->mockedEntryDecoder->addTransactionDetails(Argument::any(), Argument::any())->shouldNotBeCalled();
+        $statement->addEntry(Argument::any())->shouldNotBeCalled();
+        $xmlStatement = new \SimpleXMLElement('<content></content>');
+
+        $this->decoder->addEntries($statement->reveal(), $xmlStatement);
+    }
+
+    /**
+     * @test
+     */
+    public function it_adds_entries_if_there_are_present_in_xml()
+    {
+        $statement = $this->prophesize(DTO\Statement::class);
+        $this
+            ->mockedEntryDecoder
+            ->addTransactionDetails(
+                Argument::type(DTO\Entry::class),
+                Argument::type('\SimpleXMLElement')
+            )
+            ->shouldBeCalled()
+        ;
+        $statement->addEntry(Argument::type(DTO\Entry::class))->shouldBeCalled();
+
+        $this->decoder->addEntries($statement->reveal(), $this->getXmlStatement());
+    }
+
+    private function getXmlStatement()
+    {
+        $xmlContent = <<<XML
+<content>
+    <Bal>
+        <Amt Ccy="EUR">24.22</Amt>
+        <Dt>
+            <Dt>2014-12-30</Dt>
+        </Dt>
+        <CdtDbtInd>DBIT</CdtDbtInd>
+        <Tp>
+            <CdOrPrtry>
+                <Cd>OPBD</Cd>
+            </CdOrPrtry>
+        </Tp>
+    </Bal>
+    <Ntry>
+        <Amt Ccy="EUR">1.42</Amt>
+        <BookgDt>
+            <Dt></Dt>
+        </BookgDt>
+        <ValDt>
+            <Dt></Dt>
+        </ValDt>
+        <CdtDbtInd>DBIT</CdtDbtInd>
+        <RvslInd>true</RvslInd>
+        <NtryRef>lorem</NtryRef>
+        <AcctSvcrRef>ipsum</AcctSvcrRef>
+        <NtryDtls>
+            <Btch>
+                <PmtInfId>id</PmtInfId>
+            </Btch>
+        </NtryDtls>
+    </Ntry>
+</content>
+XML;
+
+        return new \SimpleXMLElement($xmlContent);
+    }
+}

--- a/tests/Unit/Camt053/EntryIteratorTest.php
+++ b/tests/Unit/Camt053/EntryIteratorTest.php
@@ -3,7 +3,8 @@ namespace Genkgo\Camt\Unit\Camt053;
 
 use Genkgo\Camt\AbstractTestCase;
 use Genkgo\Camt\Camt053\Decoder;
-use Genkgo\Camt\Camt053\Entry;
+use Genkgo\Camt\Camt053\MessageFormat;
+use Genkgo\Camt\Camt053\DTO;
 
 class EntryIteratorTest extends AbstractTestCase
 {
@@ -11,7 +12,7 @@ class EntryIteratorTest extends AbstractTestCase
     {
         $dom = new \DOMDocument('1.0', 'UTF-8');
         $dom->load(__DIR__.'/Stubs/camt053.multi.statement.xml');
-        return (new Decoder('/assets/camt.053.001.02.xsd'))->decode($dom);
+        return (new MessageFormat\Camt053V02)->getDecoder()->decode($dom);
     }
 
     public function testMultipleStatements()
@@ -21,7 +22,7 @@ class EntryIteratorTest extends AbstractTestCase
 
         $item = 0;
         foreach ($entries as $entry) {
-            /* @var $entry Entry */
+            /* @var DTO\Entry $entry */
             if ($item === 0) {
                 $this->assertEquals(885, $entry->getAmount()->getAmount());
                 $this->assertEquals(

--- a/tests/Unit/Camt053/MessageTest.php
+++ b/tests/Unit/Camt053/MessageTest.php
@@ -1,11 +1,11 @@
 <?php
+
 namespace Genkgo\Camt\Unit\Camt053;
 
 use Genkgo\Camt\AbstractTestCase;
 use Genkgo\Camt\Camt053\Decoder;
-use Genkgo\Camt\Camt053\GroupHeader;
-use Genkgo\Camt\Camt053\Message;
-use Genkgo\Camt\Camt053\Statement;
+use Genkgo\Camt\Camt053\MessageFormat;
+use Genkgo\Camt\Camt053\DTO;
 use Genkgo\Camt\Exception\InvalidMessageException;
 
 class MessageTest extends AbstractTestCase
@@ -14,14 +14,16 @@ class MessageTest extends AbstractTestCase
     {
         $dom = new \DOMDocument('1.0', 'UTF-8');
         $dom->load(__DIR__.'/Stubs/camt053.minimal.xml');
-        return (new Decoder('/assets/camt.053.001.02.xsd'))->decode($dom);
+
+        return (new MessageFormat\Camt053V02)->getDecoder()->decode($dom);
     }
 
     protected function getV3Message()
     {
         $dom = new \DOMDocument('1.0', 'UTF-8');
         $dom->load(__DIR__.'/Stubs/camt053.v3.xml');
-        return (new Decoder('/assets/camt.053.001.03.xsd'))->decode($dom);
+
+        return (new MessageFormat\Camt053V03)->getDecoder()->decode($dom);
     }
 
     public function testWrongDocument()
@@ -30,21 +32,22 @@ class MessageTest extends AbstractTestCase
 
         $dom = new \DOMDocument('1.0', 'UTF-8');
         $dom->load(__DIR__.'/Stubs/camt053.wrong.xml');
-        (new Decoder('/assets/camt.053.001.02.xsd'))->decode($dom);
+
+        return (new MessageFormat\Camt053V02)->getDecoder()->decode($dom);
     }
 
     public function testFiveDecimalsStatement()
     {
         $dom = new \DOMDocument('1.0', 'UTF-8');
         $dom->load(__DIR__.'/Stubs/camt053.five.decimals.xml');
-        (new Decoder('/assets/camt.053.001.02.xsd'))->decode($dom);
+        (new MessageFormat\Camt053V02)->getDecoder()->decode($dom);
     }
 
     public function testV3Document()
     {
         $dom = new \DOMDocument('1.0', 'UTF-8');
         $dom->load(__DIR__.'/Stubs/camt053.v3.xml');
-        (new Decoder('/assets/camt.053.001.03.xsd'))->decode($dom);
+        (new MessageFormat\Camt053V03)->getDecoder()->decode($dom);
     }
 
     public function testGroupHeader()
@@ -52,7 +55,7 @@ class MessageTest extends AbstractTestCase
         $message = $this->getDefaultMessage();
         $groupHeader = $message->getGroupHeader();
 
-        $this->assertInstanceOf(GroupHeader::class, $groupHeader);
+        $this->assertInstanceOf(DTO\GroupHeader::class, $groupHeader);
         $this->assertEquals('CAMT053RIB000000000001', $groupHeader->getMessageId());
         $this->assertEquals(new \DateTimeImmutable('2015-03-10T18:43:50+00:00'), $groupHeader->getCreatedOn());
     }
@@ -64,7 +67,7 @@ class MessageTest extends AbstractTestCase
 
         $this->assertCount(1, $statements);
         foreach ($statements as $statement) {
-            $this->assertInstanceOf(Statement::class, $statement);
+            $this->assertInstanceOf(DTO\Statement::class, $statement);
             $this->assertEquals('253EURNL26VAYB8060476890', $statement->getId());
             $this->assertEquals('NL26VAYB8060476890', (string) $statement->getAccount()->getIban());
             $this->assertEquals(new \DateTimeImmutable('2015-03-10T18:43:50+00:00'), $statement->getCreatedOn());

--- a/tests/Unit/ReaderTest.php
+++ b/tests/Unit/ReaderTest.php
@@ -1,9 +1,11 @@
 <?php
+
 namespace Genkgo\Camt\Unit;
 
 use DOMDocument;
 use Genkgo\Camt\AbstractTestCase;
-use Genkgo\Camt\Camt053\Message;
+use Genkgo\Camt\Camt053\DTO;
+use Genkgo\Camt\Camt053\MessageFormat;
 use Genkgo\Camt\Config;
 use Genkgo\Camt\Exception\ReaderException;
 use Genkgo\Camt\Reader;
@@ -13,7 +15,7 @@ class ReaderTest extends AbstractTestCase
     protected function getDefaultConfig()
     {
         $config = new Config();
-        $config->addMessageFormat(new Message\Camt053V02());
+        $config->addMessageFormat(new MessageFormat\Camt053V02());
         return $config;
     }
 
@@ -41,6 +43,6 @@ class ReaderTest extends AbstractTestCase
     {
         $reader = new Reader(Config::getDefault());
         $message = $reader->readFile(__DIR__.'/Camt053/Stubs/camt053.minimal.xml');
-        $this->assertInstanceOf(Message::class, $message);
+        $this->assertInstanceOf(DTO\Message::class, $message);
     }
 }


### PR DESCRIPTION
I propose these changes:

- All DTOs are now in a sub `DTO` namespace : it allows to understand more easily what is what, like a MessageFormat, a Message, a Decoder…
- The decoder in itself does not do all the job anymore. Sub decoders have been added. I thought about adding a DIC but I guess it is overkill for a small library like *camt*. The instantiation is still done in the `getDecoder()` method of the MessageFormat.

Two main advantages:
- 1/ If another Camt053 version differs just in header group, it can still use all decoders, and change only the message decoder or the entry decoder. The previous implementation encourages to add a `if (isset…) else` rather than building an appropriate decoder, IMO.
- 2/ It makes them easier to test.