### PR TITLE
Fixed Ustrd and Strd->Ref->CdtrRefInf->Ref handling.

### DIFF
--- a/src/DTO/RemittanceInformation.php
+++ b/src/DTO/RemittanceInformation.php
@@ -19,17 +19,6 @@ class RemittanceInformation
     private $creditorReferenceInformation;
 
     /**
-     * @param $message
-     * @return static
-     */
-    public static function fromUnstructured($message)
-    {
-        $information = new static;
-        $information->message = $message;
-        return $information;
-    }
-
-    /**
      * @return CreditorReferenceInformation
      */
     public function getCreditorReferenceInformation()
@@ -43,7 +32,6 @@ class RemittanceInformation
     public function setCreditorReferenceInformation($creditorReferenceInformation)
     {
         $this->creditorReferenceInformation = $creditorReferenceInformation;
-        $this->message = $creditorReferenceInformation->getRef();
     }
 
     /**
@@ -53,4 +41,13 @@ class RemittanceInformation
     {
         return $this->message;
     }
+
+    /**
+     * @param $message
+     */
+    public function setMessage($message)
+    {
+        $this->message = $message;
+    }
+
 }

--- a/src/Decoder/EntryTransactionDetail.php
+++ b/src/Decoder/EntryTransactionDetail.php
@@ -130,24 +130,27 @@ abstract class EntryTransactionDetail
             return;
         }
 
-        if (isset($xmlDetail->RmtInf->Ustrd)) {
-            $remittanceInformation = DTO\RemittanceInformation::fromUnstructured(
-                (string)$xmlDetail->RmtInf->Ustrd
-            );
-            $detail->setRemittanceInformation($remittanceInformation);
-
-            return;
-        }
-
-        if (isset($xmlDetail->RmtInf->Strd)
-            && isset($xmlDetail->RmtInf->Strd->CdtrRefInf)
-            && isset($xmlDetail->RmtInf->Strd->CdtrRefInf->Ref)
+        if (isset($xmlDetail->RmtInf->Ustrd) || (isset($xmlDetail->RmtInf->Strd)
+                                                 && isset($xmlDetail->RmtInf->Strd->CdtrRefInf)
+                                                 && isset($xmlDetail->RmtInf->Strd->CdtrRefInf->Ref))
         ) {
-            $creditorReferenceInformation = DTO\CreditorReferenceInformation::fromUnstructured(
-                (string)$xmlDetail->RmtInf->Strd->CdtrRefInf->Ref
-            );
+            
             $remittanceInformation = new DTO\RemittanceInformation();
-            $remittanceInformation->setCreditorReferenceInformation($creditorReferenceInformation);
+
+            if (isset($xmlDetail->RmtInf->Ustrd)) {
+                $remittanceInformation->setMessage((string)$xmlDetail->RmtInf->Ustrd);
+            }
+
+            if (isset($xmlDetail->RmtInf->Strd)
+                && isset($xmlDetail->RmtInf->Strd->CdtrRefInf)
+                && isset($xmlDetail->RmtInf->Strd->CdtrRefInf->Ref)
+            ) {
+                $creditorReferenceInformation = DTO\CreditorReferenceInformation::fromUnstructured(
+                    (string)$xmlDetail->RmtInf->Strd->CdtrRefInf->Ref
+                );
+                $remittanceInformation->setCreditorReferenceInformation($creditorReferenceInformation);
+                
+            }
             $detail->setRemittanceInformation($remittanceInformation);
         }
     }


### PR DESCRIPTION
Ustrd-message handling overwrites the Ref value from RmtInf, so both values can not be retrieved. 

I propose to fix it this way:
- introduce setMessage function in RemittanceInformation class and set the message if Ustrd is set 
- do not save the Ref value to message (Ustrd) 
- drop the fromUnstructured function from RemittanceInformation class as it is not needed anymore, use getMessage function instead
