### PR TITLE
Replace `mathiasverraes/money` with `moneyphp/money`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "require" : {
     "php" : ">=5.5",
     "jschaedl/iban": "~1.1.0",
-    "mathiasverraes/money": "~1.2.1"
+    "moneyphp/money": "~1.2.1"
   },
   "require-dev" : {
     "fabpot/php-cs-fixer": "^1.11",


### PR DESCRIPTION
`mathiasverraes/money` is abandoned. It was straightforward to replace it with `moneyphp/money` since it's basically the same package.