### PR TITLE
[Camt053] Debtor's and Creditor's name may not be provided

### DIFF
--- a/src/Decoder/EntryTransactionDetail.php
+++ b/src/Decoder/EntryTransactionDetail.php
@@ -76,7 +76,8 @@ abstract class EntryTransactionDetail
             if (isset($xmlRelatedParty->Cdtr)) {
                 $xmlRelatedPartyType = $xmlRelatedParty->Cdtr;
                 $xmlRelatedPartyTypeAccount = $xmlRelatedParty->CdtrAcct;
-                $relatedPartyType = $creditor = new DTO\Creditor((string) $xmlRelatedPartyType->Nm);
+                $xmlRelatedPartyName = (isset($xmlRelatedPartyType->Nm)) ? (string) $xmlRelatedPartyType->Nm : '' ;
+                $relatedPartyType = $creditor = new DTO\Creditor($xmlRelatedPartyName);
 
                 $this->addRelatedParty($detail, $xmlRelatedPartyType, $relatedPartyType, $xmlRelatedPartyTypeAccount);
             }
@@ -84,7 +85,8 @@ abstract class EntryTransactionDetail
             if (isset($xmlRelatedParty->Dbtr)) {
                 $xmlRelatedPartyType = $xmlRelatedParty->Dbtr;
                 $xmlRelatedPartyTypeAccount = $xmlRelatedParty->DbtrAcct;
-                $relatedPartyType = $debtor = new DTO\Debtor((string) $xmlRelatedPartyType->Nm);
+                $xmlRelatedPartyName = (isset($xmlRelatedPartyType->Nm)) ? (string) $xmlRelatedPartyType->Nm : '' ;
+                $relatedPartyType = $debtor = new DTO\Debtor($xmlRelatedPartyName);
 
                 $this->addRelatedParty($detail, $xmlRelatedPartyType, $relatedPartyType, $xmlRelatedPartyTypeAccount);
             }


### PR DESCRIPTION
Hi, 

According to the camt053 XSD, "Nm" node may not be provided for the entry debtor or creditor (of type PartyIdentification)

    <xs:complexType name="PartyIdentification32">
            <xs:sequence>
                <xs:element maxOccurs="1" minOccurs="0" name="Nm" type="Max140Text"/>
                <xs:element maxOccurs="1" minOccurs="0" name="PstlAdr" type="PostalAddress6"/>
                <xs:element maxOccurs="1" minOccurs="0" name="Id" type="Party6Choice"/>
                <xs:element maxOccurs="1" minOccurs="0" name="CtryOfRes" type="CountryCode"/>
                <xs:element maxOccurs="1" minOccurs="0" name="CtctDtls" type="ContactDetails2"/>
            </xs:sequence>
        </xs:complexType>

