### PR TITLE
[CAMT.054] Complete remittance information with structured and unstructured blocks

### DIFF
--- a/src/DTO/CreditorReferenceInformation.php
+++ b/src/DTO/CreditorReferenceInformation.php
@@ -14,6 +14,16 @@ class CreditorReferenceInformation
     private $ref;
 
     /**
+     * @var string
+     */
+    private $code;
+
+    /**
+     * @var string
+     */
+    private $proprietary;
+
+    /**
      * @return string
      */
     public function getRef()
@@ -39,5 +49,37 @@ class CreditorReferenceInformation
         $information = new static;
         $information->ref = $ref;
         return $information;
+    }
+
+    /**
+     * @return string
+     */
+    public function getProprietary()
+    {
+        return $this->proprietary;
+    }
+
+    /**
+     * @param string $proprietary
+     */
+    public function setProprietary($proprietary)
+    {
+        $this->proprietary = $proprietary;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCode()
+    {
+        return $this->code;
+    }
+
+    /**
+     * @param string $code
+     */
+    public function setCode($code)
+    {
+        $this->code = $code;
     }
 }

--- a/src/DTO/RemittanceInformation.php
+++ b/src/DTO/RemittanceInformation.php
@@ -19,6 +19,16 @@ class RemittanceInformation
     private $creditorReferenceInformation;
 
     /**
+     * @var StructuredRemittanceInformation
+     */
+    private $structuredRemittanceInformation;
+
+    /**
+     * @var UnstructuredRemittanceInformation
+     */
+    private $unstructuredRemittanceInformation;
+
+    /**
      * @param $message
      * @return static
      */
@@ -52,5 +62,47 @@ class RemittanceInformation
     public function getMessage()
     {
         return $this->message;
+    }
+
+    /**
+     * @param string $message
+     */
+    public function setMessage($message)
+    {
+        $this->message = $message;
+    }
+
+    /**
+     * @return StructuredRemittanceInformation
+     */
+    public function getStructuredRemittanceInformation()
+    {
+        return $this->structuredRemittanceInformation;
+    }
+
+    /**
+     * @param StructuredRemittanceInformation $structuredRemittanceInformation
+     */
+    public function setStructuredRemittanceInformation(
+            StructuredRemittanceInformation $structuredRemittanceInformation)
+    {
+        $this->structuredRemittanceInformation = $structuredRemittanceInformation;
+    }
+
+    /**
+     * @return UnstructuredRemittanceInformation
+     */
+    public function getUnstructuredRemittanceInformation()
+    {
+        return $this->unstructuredRemittanceInformation;
+    }
+
+    /**
+     * @param UnstructuredRemittanceInformation $unstructuredRemittanceInformation
+     */
+    public function setUnstructuredRemittanceInformation(
+            UnstructuredRemittanceInformation $unstructuredRemittanceInformation)
+    {
+        $this->unstructuredRemittanceInformation = $unstructuredRemittanceInformation;
     }
 }

--- a/src/DTO/RemittanceInformation.php
+++ b/src/DTO/RemittanceInformation.php
@@ -2,6 +2,8 @@
 
 namespace Genkgo\Camt\DTO;
 
+use BadMethodCallException;
+
 /**
  * Class RemittanceInformation
  * @package Genkgo\Camt\DTO
@@ -19,14 +21,14 @@ class RemittanceInformation
     private $creditorReferenceInformation;
 
     /**
-     * @var StructuredRemittanceInformation
+     * @var StructuredRemittanceInformation[]
      */
-    private $structuredRemittanceInformation;
+    private $structuredBlocks = [];
 
     /**
-     * @var UnstructuredRemittanceInformation
+     * @var UnstructuredRemittanceInformation[]
      */
-    private $unstructuredRemittanceInformation;
+    private $unstructuredBlocks = [];
 
     /**
      * @param $message
@@ -57,6 +59,7 @@ class RemittanceInformation
     }
 
     /**
+     * @deprecated Use getStructuredBlocks method instead
      * @return string
      */
     public function getMessage()
@@ -65,6 +68,7 @@ class RemittanceInformation
     }
 
     /**
+     * @deprecated Use addStructuredBlock method instead
      * @param string $message
      */
     public function setMessage($message)
@@ -73,36 +77,58 @@ class RemittanceInformation
     }
 
     /**
-     * @return StructuredRemittanceInformation
-     */
-    public function getStructuredRemittanceInformation()
-    {
-        return $this->structuredRemittanceInformation;
-    }
-
-    /**
      * @param StructuredRemittanceInformation $structuredRemittanceInformation
      */
-    public function setStructuredRemittanceInformation(
-            StructuredRemittanceInformation $structuredRemittanceInformation)
+    public function addStructuredBlock(StructuredRemittanceInformation $structuredRemittanceInformation)
     {
-        $this->structuredRemittanceInformation = $structuredRemittanceInformation;
+        return $this->structuredBlocks[] = $structuredRemittanceInformation;
     }
 
     /**
-     * @return UnstructuredRemittanceInformation
+     * @return StructuredRemittanceInformation[]
      */
-    public function getUnstructuredRemittanceInformation()
+    public function getStructuredBlocks()
     {
-        return $this->unstructuredRemittanceInformation;
+        return $this->structuredBlocks;
+    }
+
+    /**
+     * @return StructuredRemittanceInformation
+     */
+    public function getStructuredBlock()
+    {
+        if(isset($this->structuredBlocks[0])) {
+            return $this->structuredBlocks[0];
+        } else {
+            throw new BadMethodCallException('There are no structured block at all for this remittance information');
+        }
     }
 
     /**
      * @param UnstructuredRemittanceInformation $unstructuredRemittanceInformation
      */
-    public function setUnstructuredRemittanceInformation(
-            UnstructuredRemittanceInformation $unstructuredRemittanceInformation)
+    public function addUnstructuredBlock(UnstructuredRemittanceInformation $unstructuredRemittanceInformation)
     {
-        $this->unstructuredRemittanceInformation = $unstructuredRemittanceInformation;
+        return $this->unstructuredBlocks[] = $unstructuredRemittanceInformation;
+    }
+
+    /**
+     * @return UnstructuredRemittanceInformation[]
+     */
+    public function getUnstructuredBlocks()
+    {
+        return $this->unstructuredBlocks;
+    }
+
+    /**
+     * @return UnstructuredRemittanceInformation
+     */
+    public function getUnstructuredBlock()
+    {
+        if(isset($this->unstructuredBlocks[0])) {
+            return $this->unstructuredBlocks[0];
+        } else {
+            throw new BadMethodCallException('There are no unstructured block at all for this remittance information');
+        }
     }
 }

--- a/src/DTO/StructuredRemittanceInformation.php
+++ b/src/DTO/StructuredRemittanceInformation.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Genkgo\Camt\DTO;
+
+/**
+ * Class StructuredRemittanceInformation
+ * @package Genkgo\Camt\DTO
+ */
+class StructuredRemittanceInformation
+{
+    /**
+     * @var CreditorReferenceInformation
+     */
+    private $creditorReferenceInformation;
+
+    /**
+     * @var string
+     */
+    private $additionalRemittanceInformation;
+
+    /**
+     * @return string
+     */
+    public function getAdditionalRemittanceInformation()
+    {
+        return $this->additionalRemittanceInformation;
+    }
+
+    /**
+     * @param string $additionalRemittanceInformation
+     */
+    public function setAdditionalRemittanceInformation($additionalRemittanceInformation)
+    {
+        $this->additionalRemittanceInformation = $additionalRemittanceInformation;
+    }
+
+    /**
+     * @return CreditorReferenceInformation
+     */
+    public function getCreditorReferenceInformation()
+    {
+        return $this->creditorReferenceInformation;
+    }
+
+    /**
+     * @param string $creditorReferenceInformation
+     */
+    public function setCreditorReferenceInformation(CreditorReferenceInformation $creditorReferenceInformation)
+    {
+        $this->creditorReferenceInformation = $creditorReferenceInformation;
+    }
+}

--- a/src/DTO/UnstructuredRemittanceInformation.php
+++ b/src/DTO/UnstructuredRemittanceInformation.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Genkgo\Camt\DTO;
+
+/**
+ * Class UnstructuredRemittanceInformation
+ * @package Genkgo\Camt\DTO
+ */
+class UnstructuredRemittanceInformation
+{
+    /**
+     * @var string
+     */
+    private $message;
+
+    /**
+     * @param string $message
+     */
+    public function __construct($message)
+    {
+        $this->message = $message;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMessage()
+    {
+        return $this->message;
+    }
+
+    /**
+     * @param string $message
+     */
+    public function setMessage($message)
+    {
+        $this->message = $message;
+    }
+}

--- a/test/Unit/Camt054/EndToEndTest.php
+++ b/test/Unit/Camt054/EndToEndTest.php
@@ -142,26 +142,136 @@ class EndToEndTest extends AbstractTestCase
             $this->assertCount(1, $notifications);
             foreach ($notifications as $notification) {
                 $entries = $notification->getEntries();
+
                 $this->assertCount(1, $entries);
                 foreach ($entries as $entry) {
                     $transactionDetails = $entry->getTransactionDetails();
-                    $this->assertCount(2, $transactionDetails);
+
+                    $this->assertCount(3, $transactionDetails);
                     foreach ($transactionDetails as $index=>$transactionDetail) {
-                        if($index === 0) {
-                            // Legacy : The first message comes from unstructured block
-                            $this->assertEquals('Unstructured Remittance Information V1', $transactionDetail->getRemittanceInformation()->getMessage());
-                            $this->assertEquals('Unstructured Remittance Information V1', $transactionDetail->getRemittanceInformation()->getUnstructuredRemittanceInformation()->getMessage());
-                        } else {
-                            // Legacy : The second one from the ISR ref number located in the structured information because unstructured block is not present
-                            $this->assertEquals('ISR ref number V2', $transactionDetail->getRemittanceInformation()->getMessage());
-                            $this->assertEquals(null, $transactionDetail->getRemittanceInformation()->getUnstructuredRemittanceInformation());
+                        switch ($index) {
+                            case 0 :
+                                // Legacy : The first message comes from unstructured block
+                                $this->assertEquals('Unstructured Remittance Information V1',
+                                        $transactionDetail
+                                        ->getRemittanceInformation()
+                                        ->getMessage()
+                                );
+
+                                // Only one structured data block
+                                $this->assertEquals('Unstructured Remittance Information V1',
+                                        $transactionDetail
+                                        ->getRemittanceInformation()
+                                        ->getUnstructuredBlock()
+                                        ->getMessage()
+                                );
+
+                                // Check structured and unstructured blocks
+                                $this->assertEquals('ISR ref number V1', $transactionDetail->getRemittanceInformation()->getStructuredBlock()->getCreditorReferenceInformation()->getRef());
+                                $this->assertEquals('ISR Reference', $transactionDetail->getRemittanceInformation()->getStructuredBlock()->getCreditorReferenceInformation()->getProprietary());
+                                $this->assertEquals(null, $transactionDetail->getRemittanceInformation()->getStructuredBlock()->getCreditorReferenceInformation()->getCode());
+                                $this->assertEquals('Additional Remittance Information V1', $transactionDetail->getRemittanceInformation()->getStructuredBlock()->getAdditionalRemittanceInformation());
+                                break;
+                            case 1 :
+
+                                // Legacy : ref number from the structured information
+                                // because the unstructured block is not present
+                                $this->assertEquals('ISR ref number V2',
+                                        $transactionDetail
+                                        ->getRemittanceInformation()
+                                        ->getMessage()
+                                );
+
+                                // No unstructured block
+                                $this->assertEquals(0, count($transactionDetail->getRemittanceInformation()->getUnstructuredBlocks()));
+
+                                // Check structured and unstructured blocks
+                                $this->assertEquals('ISR ref number V2', $transactionDetail->getRemittanceInformation()->getStructuredBlock()->getCreditorReferenceInformation()->getRef());
+                                $this->assertEquals('ISR Reference', $transactionDetail->getRemittanceInformation()->getStructuredBlock()->getCreditorReferenceInformation()->getProprietary());
+                                $this->assertEquals(null, $transactionDetail->getRemittanceInformation()->getStructuredBlock()->getCreditorReferenceInformation()->getCode());
+                                $this->assertEquals('Additional Remittance Information V2', $transactionDetail->getRemittanceInformation()->getStructuredBlock()->getAdditionalRemittanceInformation());
+                                break;
+                            case 2 :
+                                // Legacy : ref number from the first unstructured block
+                                $this->assertEquals('Unstructured Remittance Information V3 block 1',
+                                        $transactionDetail
+                                        ->getRemittanceInformation()
+                                        ->getMessage()
+                                );
+
+                                // First unstructured block
+                                $this->assertEquals('Unstructured Remittance Information V3 block 1',
+                                        $transactionDetail
+                                        ->getRemittanceInformation()
+                                        ->getUnstructuredBlocks()[0]
+                                        ->getMessage()
+                                );
+
+                                // Second unstructured block
+                                $this->assertEquals('Unstructured Remittance Information V3 block 2',
+                                        $transactionDetail
+                                        ->getRemittanceInformation()
+                                        ->getUnstructuredBlocks()[1]
+                                        ->getMessage()
+                                );
+
+                                // Ref number from the first structured block
+                                $this->assertEquals('Ref number V3 block 1',
+                                        $transactionDetail
+                                        ->getRemittanceInformation()
+                                        ->getStructuredBlocks()[0]
+                                        ->getCreditorReferenceInformation()
+                                        ->getRef()
+                                );
+
+                                // Ref number from the second structured block
+                                $this->assertEquals('Ref number V3 block 2',
+                                        $transactionDetail
+                                        ->getRemittanceInformation()
+                                        ->getStructuredBlocks()[1]
+                                        ->getCreditorReferenceInformation()
+                                        ->getRef()
+                                );
+
+                                // Code from the first structured block
+                                $this->assertEquals('SCOR',
+                                        $transactionDetail
+                                        ->getRemittanceInformation()
+                                        ->getStructuredBlocks()[0]
+                                        ->getCreditorReferenceInformation()
+                                        ->getCode()
+                                );
+
+                                // Code from the second structured block
+                                $this->assertEquals('SCOR',
+                                        $transactionDetail
+                                        ->getRemittanceInformation()
+                                        ->getStructuredBlocks()[1]
+                                        ->getCreditorReferenceInformation()
+                                        ->getCode()
+                                );
+
+                                // Additional remittance information from the first structured block
+                                $this->assertEquals('Additional Remittance Information V3 block 1',
+                                        $transactionDetail
+                                        ->getRemittanceInformation()
+                                        ->getStructuredBlocks()[0]
+                                        ->getAdditionalRemittanceInformation()
+                                );
+
+                                // Additional remittance information from the second structured block
+                                $this->assertEquals('Additional Remittance Information V3 block 2',
+                                        $transactionDetail
+                                        ->getRemittanceInformation()
+                                        ->getStructuredBlocks()[1]
+                                        ->getAdditionalRemittanceInformation()
+                                );
+
+                                break;
+                            default :
+                                break;
                         }
 
-                        // Check structured and unstructured blocks
-                        $this->assertEquals('ISR ref number V'.($index+1), $transactionDetail->getRemittanceInformation()->getStructuredRemittanceInformation()->getCreditorReferenceInformation()->getRef());
-                        $this->assertEquals('ISR Reference', $transactionDetail->getRemittanceInformation()->getStructuredRemittanceInformation()->getCreditorReferenceInformation()->getProprietary());
-                        $this->assertEquals(null, $transactionDetail->getRemittanceInformation()->getStructuredRemittanceInformation()->getCreditorReferenceInformation()->getCode());
-                        $this->assertEquals('Additional Remittance Information V'.($index+1), $transactionDetail->getRemittanceInformation()->getStructuredRemittanceInformation()->getAdditionalRemittanceInformation());
                     }
                 }
             }

--- a/test/Unit/Camt054/EndToEndTest.php
+++ b/test/Unit/Camt054/EndToEndTest.php
@@ -150,9 +150,11 @@ class EndToEndTest extends AbstractTestCase
                         if($index === 0) {
                             // Legacy : The first message comes from unstructured block
                             $this->assertEquals('Unstructured Remittance Information V1', $transactionDetail->getRemittanceInformation()->getMessage());
+                            $this->assertEquals('Unstructured Remittance Information V1', $transactionDetail->getRemittanceInformation()->getUnstructuredRemittanceInformation()->getMessage());
                         } else {
                             // Legacy : The second one from the ISR ref number located in the structured information because unstructured block is not present
                             $this->assertEquals('ISR ref number V2', $transactionDetail->getRemittanceInformation()->getMessage());
+                            $this->assertEquals(null, $transactionDetail->getRemittanceInformation()->getUnstructuredRemittanceInformation());
                         }
 
                         // Check structured and unstructured blocks

--- a/test/Unit/Camt054/EndToEndTest.php
+++ b/test/Unit/Camt054/EndToEndTest.php
@@ -154,23 +154,49 @@ class EndToEndTest extends AbstractTestCase
                                 // Legacy : The first message comes from unstructured block
                                 $this->assertEquals('Unstructured Remittance Information V1',
                                         $transactionDetail
-                                        ->getRemittanceInformation()
-                                        ->getMessage()
+                                            ->getRemittanceInformation()
+                                            ->getMessage()
                                 );
 
                                 // Only one structured data block
                                 $this->assertEquals('Unstructured Remittance Information V1',
                                         $transactionDetail
-                                        ->getRemittanceInformation()
-                                        ->getUnstructuredBlock()
-                                        ->getMessage()
+                                            ->getRemittanceInformation()
+                                            ->getUnstructuredBlock()
+                                            ->getMessage()
                                 );
 
                                 // Check structured and unstructured blocks
-                                $this->assertEquals('ISR ref number V1', $transactionDetail->getRemittanceInformation()->getStructuredBlock()->getCreditorReferenceInformation()->getRef());
-                                $this->assertEquals('ISR Reference', $transactionDetail->getRemittanceInformation()->getStructuredBlock()->getCreditorReferenceInformation()->getProprietary());
-                                $this->assertEquals(null, $transactionDetail->getRemittanceInformation()->getStructuredBlock()->getCreditorReferenceInformation()->getCode());
-                                $this->assertEquals('Additional Remittance Information V1', $transactionDetail->getRemittanceInformation()->getStructuredBlock()->getAdditionalRemittanceInformation());
+                                $this->assertEquals('ISR ref number V1',
+                                        $transactionDetail
+                                            ->getRemittanceInformation()
+                                            ->getStructuredBlock()
+                                            ->getCreditorReferenceInformation()
+                                            ->getRef()
+                                );
+
+                                $this->assertEquals('ISR Reference',
+                                        $transactionDetail
+                                            ->getRemittanceInformation()
+                                            ->getStructuredBlock()
+                                            ->getCreditorReferenceInformation()
+                                            ->getProprietary()
+                                );
+
+                                $this->assertEquals(null,
+                                        $transactionDetail
+                                            ->getRemittanceInformation()
+                                            ->getStructuredBlock()
+                                            ->getCreditorReferenceInformation()
+                                            ->getCode()
+                                );
+
+                                $this->assertEquals('Additional Remittance Information V1',
+                                        $transactionDetail
+                                            ->getRemittanceInformation()
+                                            ->getStructuredBlock()
+                                            ->getAdditionalRemittanceInformation()
+                                );
                                 break;
                             case 1 :
 
@@ -178,95 +204,126 @@ class EndToEndTest extends AbstractTestCase
                                 // because the unstructured block is not present
                                 $this->assertEquals('ISR ref number V2',
                                         $transactionDetail
-                                        ->getRemittanceInformation()
-                                        ->getMessage()
+                                            ->getRemittanceInformation()
+                                            ->getMessage()
                                 );
 
                                 // No unstructured block
-                                $this->assertEquals(0, count($transactionDetail->getRemittanceInformation()->getUnstructuredBlocks()));
+                                $this->assertEquals(0,
+                                        count($transactionDetail
+                                                ->getRemittanceInformation()
+                                                ->getUnstructuredBlocks()
+                                        )
+                                );
 
                                 // Check structured and unstructured blocks
-                                $this->assertEquals('ISR ref number V2', $transactionDetail->getRemittanceInformation()->getStructuredBlock()->getCreditorReferenceInformation()->getRef());
-                                $this->assertEquals('ISR Reference', $transactionDetail->getRemittanceInformation()->getStructuredBlock()->getCreditorReferenceInformation()->getProprietary());
-                                $this->assertEquals(null, $transactionDetail->getRemittanceInformation()->getStructuredBlock()->getCreditorReferenceInformation()->getCode());
-                                $this->assertEquals('Additional Remittance Information V2', $transactionDetail->getRemittanceInformation()->getStructuredBlock()->getAdditionalRemittanceInformation());
+                                $this->assertEquals('ISR ref number V2',
+                                        $transactionDetail
+                                            ->getRemittanceInformation()
+                                            ->getStructuredBlock()
+                                            ->getCreditorReferenceInformation()
+                                            ->getRef()
+                                );
+
+                                $this->assertEquals('ISR Reference',
+                                        $transactionDetail
+                                            ->getRemittanceInformation()
+                                            ->getStructuredBlock()
+                                            ->getCreditorReferenceInformation()
+                                            ->getProprietary()
+                                );
+
+                                $this->assertEquals(null,
+                                        $transactionDetail
+                                            ->getRemittanceInformation()
+                                            ->getStructuredBlock()
+                                            ->getCreditorReferenceInformation()
+                                            ->getCode()
+                                );
+
+                                $this->assertEquals('Additional Remittance Information V2',
+                                        $transactionDetail
+                                            ->getRemittanceInformation()
+                                            ->getStructuredBlock()
+                                            ->getAdditionalRemittanceInformation()
+                                );
+
                                 break;
                             case 2 :
                                 // Legacy : ref number from the first unstructured block
                                 $this->assertEquals('Unstructured Remittance Information V3 block 1',
                                         $transactionDetail
-                                        ->getRemittanceInformation()
-                                        ->getMessage()
+                                            ->getRemittanceInformation()
+                                            ->getMessage()
                                 );
 
                                 // First unstructured block
                                 $this->assertEquals('Unstructured Remittance Information V3 block 1',
                                         $transactionDetail
-                                        ->getRemittanceInformation()
-                                        ->getUnstructuredBlocks()[0]
-                                        ->getMessage()
+                                            ->getRemittanceInformation()
+                                            ->getUnstructuredBlocks()[0]
+                                            ->getMessage()
                                 );
 
                                 // Second unstructured block
                                 $this->assertEquals('Unstructured Remittance Information V3 block 2',
                                         $transactionDetail
-                                        ->getRemittanceInformation()
-                                        ->getUnstructuredBlocks()[1]
-                                        ->getMessage()
+                                            ->getRemittanceInformation()
+                                            ->getUnstructuredBlocks()[1]
+                                            ->getMessage()
                                 );
 
                                 // Ref number from the first structured block
                                 $this->assertEquals('Ref number V3 block 1',
                                         $transactionDetail
-                                        ->getRemittanceInformation()
-                                        ->getStructuredBlocks()[0]
-                                        ->getCreditorReferenceInformation()
-                                        ->getRef()
+                                            ->getRemittanceInformation()
+                                            ->getStructuredBlocks()[0]
+                                            ->getCreditorReferenceInformation()
+                                            ->getRef()
                                 );
 
                                 // Ref number from the second structured block
                                 $this->assertEquals('Ref number V3 block 2',
                                         $transactionDetail
-                                        ->getRemittanceInformation()
-                                        ->getStructuredBlocks()[1]
-                                        ->getCreditorReferenceInformation()
-                                        ->getRef()
+                                            ->getRemittanceInformation()
+                                            ->getStructuredBlocks()[1]
+                                            ->getCreditorReferenceInformation()
+                                            ->getRef()
                                 );
 
                                 // Code from the first structured block
                                 $this->assertEquals('SCOR',
                                         $transactionDetail
-                                        ->getRemittanceInformation()
-                                        ->getStructuredBlocks()[0]
-                                        ->getCreditorReferenceInformation()
-                                        ->getCode()
+                                            ->getRemittanceInformation()
+                                            ->getStructuredBlocks()[0]
+                                            ->getCreditorReferenceInformation()
+                                            ->getCode()
                                 );
 
                                 // Code from the second structured block
                                 $this->assertEquals('SCOR',
                                         $transactionDetail
-                                        ->getRemittanceInformation()
-                                        ->getStructuredBlocks()[1]
-                                        ->getCreditorReferenceInformation()
-                                        ->getCode()
+                                            ->getRemittanceInformation()
+                                            ->getStructuredBlocks()[1]
+                                            ->getCreditorReferenceInformation()
+                                            ->getCode()
                                 );
 
                                 // Additional remittance information from the first structured block
                                 $this->assertEquals('Additional Remittance Information V3 block 1',
                                         $transactionDetail
-                                        ->getRemittanceInformation()
-                                        ->getStructuredBlocks()[0]
-                                        ->getAdditionalRemittanceInformation()
+                                            ->getRemittanceInformation()
+                                            ->getStructuredBlocks()[0]
+                                            ->getAdditionalRemittanceInformation()
                                 );
 
                                 // Additional remittance information from the second structured block
                                 $this->assertEquals('Additional Remittance Information V3 block 2',
                                         $transactionDetail
-                                        ->getRemittanceInformation()
-                                        ->getStructuredBlocks()[1]
-                                        ->getAdditionalRemittanceInformation()
+                                            ->getRemittanceInformation()
+                                            ->getStructuredBlocks()[1]
+                                            ->getAdditionalRemittanceInformation()
                                 );
-
                                 break;
                             default :
                                 break;

--- a/test/Unit/Camt054/Stubs/camt054.v2.xml
+++ b/test/Unit/Camt054/Stubs/camt054.v2.xml
@@ -122,7 +122,43 @@
                             <AddtlRmtInf>Additional Remittance Information V2</AddtlRmtInf>                                                                
                           </Strd>             
                         </RmtInf>                         
-                    </TxDtls>                    
+                    </TxDtls> 
+                    <TxDtls>
+                      <Refs>
+                        <EndToEndId>MUELL/FINP/RA12345</EndToEndId>
+                      </Refs>
+                      <RltdPties>
+                        <Dbtr>
+                          <Nm>MUELLER</Nm>
+                        </Dbtr>
+                      </RltdPties>
+                        <RmtInf>
+                          <Ustrd>Unstructured Remittance Information V3 block 1</Ustrd>
+                          <Ustrd>Unstructured Remittance Information V3 block 2</Ustrd>
+                          <Strd>
+                            <CdtrRefInf>
+                              <Tp>
+                                <CdOrPrtry>
+                                  <Cd>SCOR</Cd>
+                                </CdOrPrtry>
+                              </Tp>
+                              <Ref>Ref number V3 block 1</Ref>
+                            </CdtrRefInf>
+                            <AddtlRmtInf>Additional Remittance Information V3 block 1</AddtlRmtInf>                                                                
+                          </Strd>   
+                          <Strd>
+                            <CdtrRefInf>
+                              <Tp>
+                                <CdOrPrtry>
+                                  <Cd>SCOR</Cd>
+                                </CdOrPrtry>
+                              </Tp>
+                              <Ref>Ref number V3 block 2</Ref>
+                            </CdtrRefInf>
+                            <AddtlRmtInf>Additional Remittance Information V3 block 2</AddtlRmtInf>                                                                
+                          </Strd>                         
+                        </RmtInf>                        
+                    </TxDtls>                                                            
                 </NtryDtls>
             </Ntry>
             <AddtlNtfctnInf>Additional Information</AddtlNtfctnInf>

--- a/test/Unit/Camt054/Stubs/camt054.v2.xml
+++ b/test/Unit/Camt054/Stubs/camt054.v2.xml
@@ -85,7 +85,44 @@
                                 <Nm>MUELLER</Nm>
                             </Dbtr>
                         </RltdPties>
+                        <RmtInf>
+                          <Ustrd>Unstructured Remittance Information V1</Ustrd>
+                          <Strd>
+                            <CdtrRefInf>
+                              <Tp>
+                                <CdOrPrtry>
+                                  <Prtry>ISR Reference</Prtry>
+                                </CdOrPrtry>
+                              </Tp>
+                              <Ref>ISR ref number V1</Ref>
+                            </CdtrRefInf>
+                            <AddtlRmtInf>Additional Remittance Information V1</AddtlRmtInf>                                                                
+                          </Strd>              
+                        </RmtInf>                       
                     </TxDtls>
+                    <TxDtls>
+                        <Refs>
+                            <EndToEndId>MUELL/FINP/RA12345</EndToEndId>
+                        </Refs>
+                        <RltdPties>
+                            <Dbtr>
+                                <Nm>MUELLER</Nm>
+                            </Dbtr>
+                        </RltdPties>
+                        <RmtInf>
+                          <Strd>
+                            <CdtrRefInf>
+                              <Tp>
+                                <CdOrPrtry>
+                                  <Prtry>ISR Reference</Prtry>
+                                </CdOrPrtry>
+                              </Tp>
+                              <Ref>ISR ref number V2</Ref>
+                            </CdtrRefInf>
+                            <AddtlRmtInf>Additional Remittance Information V2</AddtlRmtInf>                                                                
+                          </Strd>             
+                        </RmtInf>                         
+                    </TxDtls>                    
                 </NtryDtls>
             </Ntry>
             <AddtlNtfctnInf>Additional Information</AddtlNtfctnInf>

--- a/test/Unit/Camt054/Stubs/camt054.v4.xml
+++ b/test/Unit/Camt054/Stubs/camt054.v4.xml
@@ -162,7 +162,18 @@
               </CdtrAgt>
             </RltdAgts>
             <RmtInf>
-              <Ustrd>Example Remittance Information 3 - V1</Ustrd>
+              <Ustrd>Unstructured Remittance Information V1</Ustrd>
+              <Strd>
+                <CdtrRefInf>
+                  <Tp>
+                    <CdOrPrtry>
+                      <Prtry>ISR Reference</Prtry>
+                    </CdOrPrtry>
+                  </Tp>
+                  <Ref>ISR ref number V1</Ref>
+                </CdtrRefInf>
+                <AddtlRmtInf>Additional Remittance Information V1</AddtlRmtInf>                                                                
+              </Strd>              
             </RmtInf>
           </TxDtls>
           <TxDtls>
@@ -231,7 +242,17 @@
               </CdtrAgt>
             </RltdAgts>
             <RmtInf>
-              <Ustrd>Example Remittance Information 3 - V2</Ustrd>
+              <Strd>
+                <CdtrRefInf>
+                  <Tp>
+                    <CdOrPrtry>
+                      <Prtry>ISR Reference</Prtry>
+                    </CdOrPrtry>
+                  </Tp>
+                  <Ref>ISR ref number V2</Ref>
+                </CdtrRefInf>
+                <AddtlRmtInf>Additional Remittance Information V2</AddtlRmtInf>                                                                
+              </Strd>             
             </RmtInf>
           </TxDtls>
         </NtryDtls>

--- a/test/Unit/Camt054/Stubs/camt054.v4.xml
+++ b/test/Unit/Camt054/Stubs/camt054.v4.xml
@@ -255,6 +255,98 @@
               </Strd>             
             </RmtInf>
           </TxDtls>
+          <TxDtls>
+            <Refs>
+              <PmtInfId>UXC06170000006PI00001</PmtInfId>
+              <InstrId>UXC06170000006PI00001II00002</InstrId>
+              <EndToEndId>UXC06170000006PI00001EE00002</EndToEndId>
+            </Refs>
+            <Amt Ccy="CHF">3.2</Amt>
+            <CdtDbtInd>CRDT</CdtDbtInd>
+            <AmtDtls>
+              <TxAmt>
+                <Amt Ccy="CHF">3.2</Amt>
+              </TxAmt>
+            </AmtDtls>
+            <BkTxCd>
+              <Domn>
+                <Cd>PMNT</Cd>
+                <Fmly>
+                  <Cd>ICDT</Cd>
+                  <SubFmlyCd>DMCT</SubFmlyCd>
+                </Fmly>
+              </Domn>
+              <Prtry>
+                <Cd>Z24</Cd>
+              </Prtry>
+            </BkTxCd>
+            <RltdPties>
+              <InitgPty>
+                <Nm>UNIFITS</Nm>
+              </InitgPty>
+              <Dbtr>
+                <Nm>UNIFITS GmbH</Nm>
+              </Dbtr>
+              <DbtrAcct>
+                <Id>
+                  <IBAN>CH2801234000123456789</IBAN>
+                </Id>
+              </DbtrAcct>
+              <Cdtr>
+                <Nm>Example Creditor 3 - V3</Nm>
+                <PstlAdr>
+                  <StrtNm>Example Street 3 - V3</StrtNm>
+                  <BldgNb>32</BldgNb>
+                  <PstCd>3232</PstCd>
+                  <TwnNm>Example Town 3 - V3</TwnNm>
+                  <Ctry>CH</Ctry>
+                </PstlAdr>
+              </Cdtr>
+              <CdtrAcct>
+                <Id>
+                  <IBAN>CH7212345003232323232</IBAN>
+                </Id>
+              </CdtrAcct>
+            </RltdPties>
+            <RltdAgts>
+              <DbtrAgt>
+                <FinInstnId>
+                  <BICFI>BANKCHZHXXX</BICFI>
+                </FinInstnId>
+              </DbtrAgt>
+              <CdtrAgt>
+                <FinInstnId>
+                  <BICFI>BANKCHBE</BICFI>
+                </FinInstnId>
+              </CdtrAgt>
+            </RltdAgts>
+            <RmtInf>
+              <Ustrd>Unstructured Remittance Information V3 block 1</Ustrd>
+              <Ustrd>Unstructured Remittance Information V3 block 2</Ustrd>
+              <Strd>
+                <CdtrRefInf>
+                  <Tp>
+                    <CdOrPrtry>
+                      <Cd>SCOR</Cd>
+                    </CdOrPrtry>
+                  </Tp>
+                  <Ref>Ref number V3 block 1</Ref>
+                </CdtrRefInf>
+                <AddtlRmtInf>Additional Remittance Information V3 block 1</AddtlRmtInf>                                                                
+              </Strd>   
+              <Strd>
+                <CdtrRefInf>
+                  <Tp>
+                    <CdOrPrtry>
+                      <Cd>SCOR</Cd>
+                    </CdOrPrtry>
+                  </Tp>
+                  <Ref>Ref number V3 block 2</Ref>
+                </CdtrRefInf>
+                <AddtlRmtInf>Additional Remittance Information V3 block 2</AddtlRmtInf>                                                                
+              </Strd>                         
+            </RmtInf>
+          </TxDtls>          
         </NtryDtls>
         <AddtlNtryInf>Order</AddtlNtryInf>
       </Ntry>


### PR DESCRIPTION
Regarding #58, ISR reference number can be lost if unstructured and structured blocks are present in a transaction details.

This feature don't break the compatibility and let the user decides to use the legacy `$transactionDetail->getRemittanceInformation()->getMessage();` method to retrieve remittance information or use the `StructuredRemittanceInformationand` and `UnstructuredRemittanceInformation ` new classes.

**ISR reference number**
`$transactionDetail->getRemittanceInformation()->getStructuredRemittanceInformation()->getCreditorReferenceInformation()->getRef()`

**Additional remittance information (usually the reject code in Switzerland)**
`$transactionDetail->getRemittanceInformation()->getStructuredRemittanceInformation()->getAdditionalRemittanceInformation()`

**Unstructured data  (usually the reject code in Switzerland)**
`$transactionDetail->getRemittanceInformation()->getUnstructuredRemittanceInformation()->getMessage()`