### PR TITLE
Add opening balance code PRCD

### DIFF
--- a/src/Decoder/Record.php
+++ b/src/Decoder/Record.php
@@ -50,24 +50,22 @@ class Record
                 $code = (string) $xmlBalance->Tp->CdOrPrtry->Cd;
 
                 if (in_array($code, ['OPBD', 'PRCD'])) {
-                    $balance = DTO\Balance::opening(
+                    $record->addBalance(DTO\Balance::opening(
                         new Money(
                             $amount,
                             new Currency($currency)
                         ),
                         $this->dateDecoder->decode($date)
-                    );
+                    ));
                 } elseif ($code === 'CLBD') {
-                    $balance = DTO\Balance::closing(
+                    $record->addBalance(DTO\Balance::closing(
                         new Money(
                             $amount,
                             new Currency($currency)
                         ),
                         $this->dateDecoder->decode($date)
-                    );
+                    ));
                 }
-
-                $record->addBalance($balance);
             }
         }
     }

--- a/src/Decoder/Record.php
+++ b/src/Decoder/Record.php
@@ -46,28 +46,29 @@ class Record
                 $amount = $amount * -1;
             }
 
-            if (isset($xmlBalance->Tp)
-                && isset($xmlBalance->Tp->CdOrPrtry)
-                && (string) $xmlBalance->Tp->CdOrPrtry->Cd === 'OPBD'
-            ) {
-                $balance = DTO\Balance::opening(
-                    new Money(
-                        $amount,
-                        new Currency($currency)
-                    ),
-                    $this->dateDecoder->decode($date)
-                );
-            } else {
-                $balance = DTO\Balance::closing(
-                    new Money(
-                        $amount,
-                        new Currency($currency)
-                    ),
-                    $this->dateDecoder->decode($date)
-                );
-            }
+            if (isset($xmlBalance->Tp) && isset($xmlBalance->Tp->CdOrPrtry)) {
+                $code = (string) $xmlBalance->Tp->CdOrPrtry->Cd;
 
-            $record->addBalance($balance);
+                if (in_array($code, ['OPBD', 'PRCD'])) {
+                    $balance = DTO\Balance::opening(
+                        new Money(
+                            $amount,
+                            new Currency($currency)
+                        ),
+                        $this->dateDecoder->decode($date)
+                    );
+                } elseif ($code === 'CLBD') {
+                    $balance = DTO\Balance::closing(
+                        new Money(
+                            $amount,
+                            new Currency($currency)
+                        ),
+                        $this->dateDecoder->decode($date)
+                    );
+                }
+
+                $record->addBalance($balance);
+            }
         }
     }
 
@@ -164,10 +165,9 @@ class Record
                 $chargesRecords = $xmlEntry->Chrgs->Rcrd;
                 if ($chargesRecords) {
                     foreach ($chargesRecords as $chargesRecord) {
-
                         $chargesDetail = new DTO\ChargesRecord();
 
-                        if(isset($chargesRecord->Amt) && (string) $chargesRecord->Amt) {
+                        if (isset($chargesRecord->Amt) && (string) $chargesRecord->Amt) {
                             $amount      = StringToUnits::convert((string) $chargesRecord->Amt);
                             $currency    = (string)$chargesRecord->Amt['Ccy'];
 


### PR DESCRIPTION
Besides `OPBD (OpeningBooked)`, `PRCD (PreviouslyClosedBooked)` is also used to indicate the opening balance. Moreover, explicitly check for `CLBD (ClosingBooked)` to avoid incorrectly marking unknown codes as closing balance (what happened to me with `PRCD`!).

Thank you!

Jarno