### PR TITLE
Update moneyphp to v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "require": {
         "php": "^7.0",
         "jschaedl/iban": "~1.1.0",
-        "moneyphp/money": "~1.2.1"
+        "moneyphp/money": "^3"
     },
     "require-dev": {
         "fabpot/php-cs-fixer": "^1.11",

--- a/src/Decoder.php
+++ b/src/Decoder.php
@@ -1,13 +1,8 @@
 <?php
 namespace Genkgo\Camt;
 
-use DateTimeImmutable;
 use DOMDocument;
-use Genkgo\Camt\DecoderInterface;
 use Genkgo\Camt\Exception\InvalidMessageException;
-use Genkgo\Camt\Util\StringToUnits;
-use Money\Currency;
-use Money\Money;
 use SimpleXMLElement;
 
 /**

--- a/test/Unit/Camt052/EndToEndTest.php
+++ b/test/Unit/Camt052/EndToEndTest.php
@@ -116,7 +116,7 @@ class EndToEndTest extends AbstractTestCase
 
                 foreach ($entries as $entry) {
                     $this->assertEquals(-20000000, $entry->getAmount()->getAmount());
-                    $this->assertEquals('SEK', $entry->getAmount()->getCurrency()->getName());
+                    $this->assertEquals('SEK', $entry->getAmount()->getCurrency()->getCode());
                     $this->assertEquals('2007-10-18', $entry->getBookingDate()->format('Y-m-d'));
                     $this->assertEquals('2007-10-18', $entry->getValueDate()->format('Y-m-d'));
                     $this->assertEquals('Credit', $entry->getAdditionalInfo());

--- a/test/Unit/Camt053/EndToEndTest.php
+++ b/test/Unit/Camt053/EndToEndTest.php
@@ -159,13 +159,13 @@ class EndToEndTest extends AbstractTestCase
                 foreach ($balances as $item => $balance) {
                     if ($item === 0) {
                         $this->assertEquals(1815, $balance->getAmount()->getAmount());
-                        $this->assertEquals('EUR', $balance->getAmount()->getCurrency()->getName());
+                        $this->assertEquals('EUR', $balance->getAmount()->getCurrency()->getCode());
                         $this->assertEquals('opening', $balance->getType());
                     }
 
                     if ($item === 1) {
                         $this->assertEquals(-2700, $balance->getAmount()->getAmount());
-                        $this->assertEquals('SEK', $balance->getAmount()->getCurrency()->getName());
+                        $this->assertEquals('SEK', $balance->getAmount()->getCurrency()->getCode());
                         $this->assertEquals('closing', $balance->getType());
                     }
                 }
@@ -192,7 +192,7 @@ class EndToEndTest extends AbstractTestCase
 
                 foreach ($entries as $entry) {
                     $this->assertEquals(885, $entry->getAmount()->getAmount());
-                    $this->assertEquals('EUR', $entry->getAmount()->getCurrency()->getName());
+                    $this->assertEquals('EUR', $entry->getAmount()->getCurrency()->getCode());
                     $this->assertEquals('2014-12-31', $entry->getBookingDate()->format('Y-m-d'));
                     $this->assertEquals('2015-01-02', $entry->getValueDate()->format('Y-m-d'));
 

--- a/test/Unit/Camt054/EndToEndTest.php
+++ b/test/Unit/Camt054/EndToEndTest.php
@@ -118,7 +118,7 @@ class EndToEndTest extends AbstractTestCase
 
                 foreach ($entries as $entry) {
                     $this->assertEquals(-20000000, $entry->getAmount()->getAmount());
-                    $this->assertEquals('SEK', $entry->getAmount()->getCurrency()->getName());
+                    $this->assertEquals('SEK', $entry->getAmount()->getCurrency()->getCode());
                     $this->assertEquals('2007-10-18', $entry->getBookingDate()->format('Y-m-d'));
                     $this->assertEquals('2007-10-18', $entry->getValueDate()->format('Y-m-d'));
                     $this->assertEquals('PMNT', $entry->getBankTransactionCode()->getDomain()->getCode());


### PR DESCRIPTION
Money (https://github.com/moneyphp/money) is currently at v3. It's mostly compatible, except for the Currency api change. This upgrades to v3. Tests are passing.