### PR TITLE
Feature/xsd novalidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,27 @@ $reader = new Reader(Config::getDefault());
 $message = $reader->readFile(__DIR__.'/Camt053/Stubs/camt053.v2.minimal.xml');
 $statements = $message->getRecords();
 foreach ($statements as $statement) {
-  $entries = $statement->getEntries();
+    $entries = $statement->getEntries();
 }
 ```
+
+
+
+### XSD validation
+   
+This library provides a XSD validation for each supported CAMT format. The validation is executed by default. But in some cases, you might want to disable it.
+
+```php
+<?php
+use Genkgo\Camt\Config;
+use Genkgo\Camt\Reader;
+
+$config = Config::getDefault();
+$config->disableXsdValidation();
+
+$reader = new Reader($config);
+```
+   
 
 ## Contributing
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -18,6 +18,11 @@ class Config
     private $messageFormats = [];
 
     /**
+     * @var bool
+     */
+    private $xsdValidation = true;
+
+    /**
      * @param MessageFormatInterface $messageFormat
      */
     public function addMessageFormat(MessageFormatInterface $messageFormat)
@@ -31,6 +36,19 @@ class Config
     public function getMessageFormats()
     {
         return $this->messageFormats;
+    }
+
+    public function disableXsdValidation()
+    {
+        $this->xsdValidation = false;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getXsdValidation()
+    {
+        return $this->xsdValidation;
     }
 
     /**

--- a/src/Decoder.php
+++ b/src/Decoder.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Genkgo\Camt;
 
 use DOMDocument;
@@ -7,6 +8,7 @@ use SimpleXMLElement;
 
 /**
  * Class Decoder
+ *
  * @package Genkgo\Camt
  */
 class Decoder implements DecoderInterface
@@ -23,6 +25,7 @@ class Decoder implements DecoderInterface
 
     /**
      * Path to the schema definition
+     *
      * @var string
      */
     protected $schemeDefinitionPath;
@@ -39,12 +42,13 @@ class Decoder implements DecoderInterface
 
     /**
      * @param DOMDocument $document
+     *
      * @throws InvalidMessageException
      */
     private function validate(DOMDocument $document)
     {
         libxml_use_internal_errors(true);
-        $valid = $document->schemaValidate(dirname(__DIR__).$this->schemeDefinitionPath);
+        $valid  = $document->schemaValidate(dirname(__DIR__) . $this->schemeDefinitionPath);
         $errors = libxml_get_errors();
         libxml_clear_errors();
 
@@ -61,12 +65,16 @@ class Decoder implements DecoderInterface
 
     /**
      * @param DOMDocument $document
-     * @return Message
-     * @throws InvalidMessageException
+     * @param bool        $xsdValidation
+     *
+     * @return DTO\Message
      */
-    public function decode(DOMDocument $document)
+    public function decode(DOMDocument $document, $xsdValidation = true)
     {
-        $this->validate($document);
+        if ($xsdValidation === true) {
+            $this->validate($document);
+        }
+
         $this->document = simplexml_import_dom($document);
 
         $message = new DTO\Message();

--- a/src/DecoderInterface.php
+++ b/src/DecoderInterface.php
@@ -2,7 +2,7 @@
 namespace Genkgo\Camt;
 
 use DOMDocument;
-use Genkgo\Camt\Camt053\Message;
+use Genkgo\Camt\DTO\Message;
 
 interface DecoderInterface
 {
@@ -10,5 +10,5 @@ interface DecoderInterface
      * @param DOMDocument $document
      * @return mixed|Message
      */
-    public function decode(DOMDocument $document);
+    public function decode(DOMDocument $document, $xsdValidation = true);
 }

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -43,7 +43,7 @@ class Reader
         $xmlNs = $document->documentElement->getAttribute('xmlns');
         $this->messageFormat = $this->getMessageFormatForXmlNs($xmlNs);
 
-        return $this->messageFormat->getDecoder()->decode($document);
+        return $this->messageFormat->getDecoder()->decode($document, $this->config->getXsdValidation());
     }
 
     /**

--- a/test/Unit/ConfigTest.php
+++ b/test/Unit/ConfigTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Genkgo\TestCamt\Unit;
+
+use Genkgo\Camt\Config;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group config
+ */
+class ConfigTest extends TestCase
+{
+    public function testDefaultConfigHasXsdValidation()
+    {
+        $config = Config::getDefault();
+
+        $this->assertTrue($config->getXsdValidation());
+    }
+
+    public function testNoValidateConfigHasNoXsdValidation()
+    {
+        $config = Config::getDefault();
+        $config->disableXsdValidation();
+
+        $this->assertFalse($config->getXsdValidation());
+    }
+}

--- a/test/Unit/ReaderTest.php
+++ b/test/Unit/ReaderTest.php
@@ -46,4 +46,15 @@ class ReaderTest extends AbstractTestCase
         $message = $reader->readFile(__DIR__.'/Camt053/Stubs/camt053.v2.minimal.xml');
         $this->assertInstanceOf(DTO\Message::class, $message);
     }
+
+
+    public function testReadFileWithNoXsdValidation()
+    {
+        $config = Config::getDefault();
+        $config->disableXsdValidation();
+
+        $reader = new Reader($config);
+        $message = $reader->readFile(__DIR__.'/Camt053/Stubs/camt053.v2.minimal.xml');
+        $this->assertInstanceOf(DTO\Message::class, $message);
+    }
 }


### PR DESCRIPTION
This PR provides a way to disable XSD validation. (Related to #18 )
Default behavior has been kept.

To disable the validation simply do 
`$reader = new Reader(Config::noValidate());`


