### PR TITLE
Stop using abandoned IBAN validator.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
 php:
+  - 7.0
   - 7.1
   - 7.2
   - nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 php:
-  - 7.0
   - 7.1
+  - 7.2
   - nightly
 script:
   - vendor/bin/phpunit --coverage-clover=coverage.clover

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Library to read CAMT files. Currently only CAMT.052, CAMT.053 and CAMT.054 are s
 
 ### Installation
 
-Requires PHP 7.1 or later. In case this is an obstacle for you, conversion should be no problem. The library is very small.
+Requires PHP 7.0 or later. In case this is an obstacle for you, conversion should be no problem. The library is very small.
 
 It is installable and autoloadable via Composer as [genkgo/camt](https://packagist.org/packages/genkgo/camt).
 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ Library to read CAMT files. Currently only CAMT.052, CAMT.053 and CAMT.054 are s
 
 ### Installation
 
-Requires PHP 5.5 or later. There are no plans to support PHP 5.4 or PHP 5.3. In case this is an obstacle for you,
-conversion should be no problem. The library is very small.
+Requires PHP 7.1 or later. In case this is an obstacle for you, conversion should be no problem. The library is very small.
 
 It is installable and autoloadable via Composer as [genkgo/camt](https://packagist.org/packages/genkgo/camt).
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Library to read CAMT files (XML containing bank statements).",
     "require": {
         "php": "^7.0",
-        "jschaedl/iban": "~1.1.0",
+        "jschaedl/iban-validation": "^1.1",
         "moneyphp/money": "^3"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,8 @@
     "name": "genkgo/camt",
     "description": "Library to read CAMT files (XML containing bank statements).",
     "require": {
-        "php": "^7.1",
-        "jschaedl/iban-validation": "^1.1",
+        "php": "^7.0",
+        "globalcitizen/php-iban": "^2.6",
         "moneyphp/money": "^3"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "genkgo/camt",
     "description": "Library to read CAMT files (XML containing bank statements).",
     "require": {
-        "php": "^7.0",
+        "php": "^7.1",
         "jschaedl/iban-validation": "^1.1",
         "moneyphp/money": "^3"
     },

--- a/src/Iban.php
+++ b/src/Iban.php
@@ -1,8 +1,6 @@
 <?php
 namespace Genkgo\Camt;
 
-use Iban\Validation\Validator as IBANValidator;
-
 /**
  * Class Iban
  * @package Genkgo\Camt
@@ -19,11 +17,11 @@ class Iban
      */
     public function __construct($iban)
     {
-        $validator = new IBANValidator();
-        if (!$validator->validate($iban)) {
+        if (!verify_iban($iban)) {
             throw new \InvalidArgumentException("Unknown IBAN {$iban}");
         }
-        $this->iban = $iban;
+        
+        $this->iban = iban_to_machine_format($iban);
     }
 
     /**
@@ -44,10 +42,6 @@ class Iban
 
     public function equals($iban)
     {
-        if ($iban === $this->iban) {
-            return true;
-        }
-
-        return preg_replace('/[^A-Za-z0-9]/', '', $iban) === $this->iban;
+        return iban_to_machine_format($iban) === $this->iban;
     }
 }

--- a/src/Iban.php
+++ b/src/Iban.php
@@ -1,7 +1,7 @@
 <?php
 namespace Genkgo\Camt;
 
-use IBAN\Validation\IBANValidator;
+use Iban\Validation\Validator as IBANValidator;
 
 /**
  * Class Iban

--- a/test/Unit/IbanTest.php
+++ b/test/Unit/IbanTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Genkgo\TestCamt\Unit;
+
+use InvalidArgumentException;
+use Genkgo\TestCamt\AbstractTestCase;
+use Genkgo\Camt\Iban;
+
+class IbanTest extends AbstractTestCase
+{
+    public function testValidIbanMachineFormat()
+    {
+        $iban = new Iban($expected = "NL91ABNA0417164300");
+
+        $this->assertEquals($expected, $iban->getIban());
+        $this->assertEquals($expected, $iban);
+    }
+
+    public function testValidIbanHumanFormat()
+    {
+        $expected = "NL91ABNA0417164300";
+
+        $iban = new Iban("IBAN NL91 ABNA 0417 1643 00");
+
+        $this->assertEquals($expected, $iban->getIban());
+        $this->assertEquals($expected, $iban);
+    }
+
+    public function testInvalidIban()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new Iban("NL91ABNA0417164301");
+    }
+}


### PR DESCRIPTION
Stop receiving `Package jschaedl/iban is abandoned, you should avoid using it. Use jschaedl/iban-validation instead.`. ~~Because the new package requires PHP 7.1+, this project will also need to require PHP 7.1+.~~ Now use `globalcitizen/php-iban` 

Thanks in advance for merging!

Regards,
Jarno