### PR TITLE
Replace deprecated dependency jschaedl/Iban with jschaedl/iban-validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,8 @@
     "description": "Library to read CAMT files (XML containing bank statements).",
     "require": {
         "php": "^7.0",
-        "jschaedl/iban": "~1.1.0",
-        "moneyphp/money": "^3"
+        "moneyphp/money": "^3",
+        "jschaedl/iban-validation": "^1.1"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^1.11",

--- a/src/Iban.php
+++ b/src/Iban.php
@@ -1,7 +1,7 @@
 <?php
 namespace Genkgo\Camt;
 
-use IBAN\Validation\IBANValidator;
+use Iban\Validation\Validator;
 
 /**
  * Class Iban
@@ -19,7 +19,7 @@ class Iban
      */
     public function __construct($iban)
     {
-        $validator = new IBANValidator();
+        $validator = new Validator();
         if (!$validator->validate($iban)) {
             throw new \InvalidArgumentException("Unknown IBAN {$iban}");
         }


### PR DESCRIPTION
- Replaced IBANValidator class with Validator class according to the new library

Resolves #75 