### PR TITLE
 Use jschaedl/iban-validation instead of globalcitizen/php-iban.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "ext-dom": "*",
         "ext-libxml": "*",
         "ext-simplexml": "*",
-        "globalcitizen/php-iban": "^2.6",
+        "jschaedl/iban-validation": "^1.3",
         "moneyphp/money": "^3"
     },
     "require-dev": {

--- a/src/Iban.php
+++ b/src/Iban.php
@@ -30,7 +30,7 @@ class Iban
     {
         return $this->iban;
     }
-    
+
     public function __toString(): string
     {
         return $this->iban;

--- a/src/Iban.php
+++ b/src/Iban.php
@@ -1,6 +1,9 @@
 <?php
 namespace Genkgo\Camt;
 
+use Iban\Validation\Validator;
+use Iban\Validation\Iban as IbanDetails;
+
 /**
  * Class Iban
  * @package Genkgo\Camt
@@ -12,36 +15,29 @@ class Iban
      */
     private $iban;
 
-    /**
-     * @param string $iban
-     */
-    public function __construct($iban)
+    public function __construct(string $iban)
     {
-        if (!verify_iban($iban)) {
+        $iban = new IbanDetails($iban);
+
+        if (!(new Validator)->validate($iban)) {
             throw new \InvalidArgumentException("Unknown IBAN {$iban}");
         }
-        
-        $this->iban = iban_to_machine_format($iban);
+
+        $this->iban = $iban->getNormalizedIban();
     }
 
-    /**
-     * @return string
-     */
-    public function getIban()
+    public function getIban(): string
+    {
+        return $this->iban;
+    }
+    
+    public function __toString(): string
     {
         return $this->iban;
     }
 
-    /**
-     * @return string
-     */
-    public function __toString()
+    public function equals($iban): bool
     {
-        return $this->iban;
-    }
-
-    public function equals($iban)
-    {
-        return iban_to_machine_format($iban) === $this->iban;
+        return (new IbanDetails($iban))->getNormalizedIban() === $this->iban;
     }
 }


### PR DESCRIPTION
As discussed in https://github.com/genkgo/camt/pull/74. 

We moved to globalcitizen/php-iban because jschaedl/iban-validation required PHP 7.1. Because the next release is going to be PHP 7.2 we can move back to jschaedl/iban-validation.

Also added some return and parameter types.