### PR TITLE
Improve PHPUnit fixture methods

### DIFF
--- a/test/Unit/Camt052/Decoder/MessageTest.php
+++ b/test/Unit/Camt052/Decoder/MessageTest.php
@@ -21,7 +21,7 @@ class MessageTest extends AbstractTestCase
     /** @var Message */
     private $decoder;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $entry = $this->prophesize(DecoderObject\Entry::class);
         $this->mockedRecordDecoder = $this

--- a/test/Unit/Camt053/Decoder/MessageTest.php
+++ b/test/Unit/Camt053/Decoder/MessageTest.php
@@ -21,7 +21,7 @@ class MessageTest extends AbstractTestCase
     /** @var Message */
     private $decoder;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $entry = $this->prophesize(DecoderObject\Entry::class);
         $this->mockedRecordDecoder = $this

--- a/test/Unit/Camt054/Decoder/MessageTest.php
+++ b/test/Unit/Camt054/Decoder/MessageTest.php
@@ -21,7 +21,7 @@ class MessageTest extends AbstractTestCase
     /** @var Message */
     private $decoder;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $entry = $this->prophesize(DecoderObject\Entry::class);
         $this->mockedRecordDecoder = $this

--- a/test/Unit/Decoder/EntryTest.php
+++ b/test/Unit/Decoder/EntryTest.php
@@ -19,7 +19,7 @@ class EntryTest extends AbstractTestCase
     /** @var Decoder\Entry */
     private $decoder;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->mockedEntryTransactionDetailDecoder = $this->prophesize(Decoder\EntryTransactionDetail::class);
         $this->decoder = new Decoder\Entry($this->mockedEntryTransactionDetailDecoder->reveal());

--- a/test/Unit/Decoder/RecordTest.php
+++ b/test/Unit/Decoder/RecordTest.php
@@ -20,7 +20,7 @@ class RecordTest extends AbstractTestCase
     /** @var Decoder\Record */
     private $decoder;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $entryTransactionDetail = $this->prophesize(Decoder\EntryTransactionDetail::class);
         $this->mockedEntryDecoder = $this


### PR DESCRIPTION
# Changed log
- According to the [PHPUnit fixture reference](https://phpunit.readthedocs.io/en/8.5/fixtures.html?highlight=fixtures), the `setUp` method should be `protected`.