### PR TITLE
Update CreditorReferenceInformation.php

### DIFF
--- a/src/DTO/CreditorReferenceInformation.php
+++ b/src/DTO/CreditorReferenceInformation.php
@@ -11,7 +11,7 @@ namespace Genkgo\Camt\DTO;
 class CreditorReferenceInformation
 {
     /**
-     * @var string
+     * @var null|string
      */
     private $ref;
 
@@ -26,7 +26,7 @@ class CreditorReferenceInformation
     private $proprietary;
 
     /**
-     * @return string
+     * @return null|string
      */
     public function getRef(): ?string
     {
@@ -34,9 +34,9 @@ class CreditorReferenceInformation
     }
 
     /**
-     * @param string $ref
+     * @param null|string $ref
      */
-    public function setRef(string $ref): void
+    public function setRef(?string $ref): void
     {
         $this->ref = $ref;
     }

--- a/src/DTO/CreditorReferenceInformation.php
+++ b/src/DTO/CreditorReferenceInformation.php
@@ -28,7 +28,7 @@ class CreditorReferenceInformation
     /**
      * @return string
      */
-    public function getRef(): string
+    public function getRef(): ?string
     {
         return $this->ref;
     }


### PR DESCRIPTION
Fixing Fatal Error when getRef() is null:

Fatal error: Uncaught TypeError: Return value of Genkgo\Camt\DTO\CreditorReferenceInformation::getRef() must be of the type string, null returned in genkgo/camt/src/DTO/CreditorReferenceInformation.php:33Stack trace: #0 genkgo/camt/src/DTO/RemittanceInformation.php(61): Genkgo\Camt\DTO\CreditorReferenceInformation->getRef() #1 genkgo/camt/src/Decoder/EntryTransactionDetail.php(239): Genkgo\Camt\DTO\RemittanceInformation->setCreditorReferenceInformation(Object(Genkgo\Camt\DTO\CreditorReferenceInformation)) #2 genkgo/camt/src/Decoder/Entry.php(36): Genkgo\Camt\Decoder\EntryTransactionDetail->addRemittanceInformation(Object(Genkgo\Camt\DTO\EntryTransactionDetail), Object(SimpleXMLElement)) #3 genkgo/camt/src/Decoder/Record.php(202): Genkgo\Camt\Decoder\Entry->addTransactionDetails(Object(Genkgo\Camt\DTO\Entry), Object(SimpleXMLElement)) #4 /w in genkgo/camt/src/DTO/CreditorReferenceInformation.php on line 33