### PR TITLE
BankTransactionCode must allow NULL Domain and Proprietary elements

### DIFF
--- a/src/DTO/BankTransactionCode.php
+++ b/src/DTO/BankTransactionCode.php
@@ -16,7 +16,7 @@ class BankTransactionCode
      */
     private $domain;
 
-    public function getProprietary(): ProprietaryBankTransactionCode
+    public function getProprietary(): ?ProprietaryBankTransactionCode
     {
         return $this->proprietary;
     }
@@ -26,7 +26,7 @@ class BankTransactionCode
         $this->proprietary = $proprietary;
     }
 
-    public function getDomain(): DomainBankTransactionCode
+    public function getDomain(): ?DomainBankTransactionCode
     {
         return $this->domain;
     }


### PR DESCRIPTION
Because "BkTxCd" block has optionnal elements "Domn" and "Prtry", it must be allowed to return NULL.

XSD extract : 

https://github.com/genkgo/camt/blob/6391eed681f6f1e75fad4e720989bcc14e9da547/assets/camt.054.001.04.xsd#L156-L161