### PR TITLE
Case with no charge

### DIFF
--- a/src/DTO/Charges.php
+++ b/src/DTO/Charges.php
@@ -18,7 +18,7 @@ class Charges
      */
     private $records = [];
 
-    public function getTotalChargesAndTaxAmount(): Money
+    public function getTotalChargesAndTaxAmount(): ?Money
     {
         return $this->totalChargesAndTaxAmount;
     }


### PR DESCRIPTION
When parsing a CAMT.054 file, setTotalChargesAndTaxAmount is only called when a `Chrgs` record exists. Therefore, `getTotalChargesAndTaxAmount` must allow to return NULL