### PR TITLE
Create IBAN validator in message/transaction detail for increased speed

### DIFF
--- a/src/Camt052/Decoder/EntryTransactionDetail.php
+++ b/src/Camt052/Decoder/EntryTransactionDetail.php
@@ -25,7 +25,7 @@ class EntryTransactionDetail extends BaseDecoder
         }
 
         if (isset($xmlRelatedPartyTypeAccount->Id->IBAN)) {
-            return new DTO\IbanAccount(new Iban((string) $xmlRelatedPartyTypeAccount->Id->IBAN));
+            return new DTO\IbanAccount(new Iban((string) $xmlRelatedPartyTypeAccount->Id->IBAN, $this->ibanValidator));
         }
 
         if (isset($xmlRelatedPartyTypeAccount->Id->BBAN)) {

--- a/src/Camt052/Decoder/Message.php
+++ b/src/Camt052/Decoder/Message.php
@@ -50,7 +50,7 @@ abstract class Message extends BaseMessageDecoder
     protected function getAccount(SimpleXMLElement $xmlRecord): Account
     {
         if (isset($xmlRecord->Acct->Id->IBAN)) {
-            return new DTO\IbanAccount(new Iban((string) $xmlRecord->Acct->Id->IBAN));
+            return new DTO\IbanAccount(new Iban((string) $xmlRecord->Acct->Id->IBAN, $this->ibanValidator));
         }
 
         if (isset($xmlRecord->Acct->Id->BBAN)) {

--- a/src/Camt053/Decoder/EntryTransactionDetail.php
+++ b/src/Camt053/Decoder/EntryTransactionDetail.php
@@ -25,7 +25,7 @@ class EntryTransactionDetail extends BaseDecoder
         }
 
         if (isset($xmlRelatedPartyTypeAccount->Id->IBAN) && $ibanCode = (string) $xmlRelatedPartyTypeAccount->Id->IBAN) {
-            return new DTO\IbanAccount(new Iban($ibanCode));
+            return new DTO\IbanAccount(new Iban($ibanCode, $this->ibanValidator));
         }
 
         if (false === isset($xmlRelatedPartyTypeAccount->Id->Othr)) {

--- a/src/Camt053/Decoder/Message.php
+++ b/src/Camt053/Decoder/Message.php
@@ -56,7 +56,7 @@ class Message extends BaseMessageDecoder
     protected function getAccount(SimpleXMLElement $xmlRecord): DTO\Account
     {
         if (isset($xmlRecord->Acct->Id->IBAN)) {
-            return new DTO\IbanAccount(new Iban((string) $xmlRecord->Acct->Id->IBAN));
+            return new DTO\IbanAccount(new Iban((string) $xmlRecord->Acct->Id->IBAN, $this->ibanValidator));
         }
 
         $xmlOtherIdentification = $xmlRecord->Acct->Id->Othr;

--- a/src/Camt054/Decoder/EntryTransactionDetail.php
+++ b/src/Camt054/Decoder/EntryTransactionDetail.php
@@ -25,7 +25,7 @@ class EntryTransactionDetail extends BaseDecoder
         }
 
         if (isset($xmlRelatedPartyTypeAccount->Id->IBAN)) {
-            return new DTO\IbanAccount(new Iban((string) $xmlRelatedPartyTypeAccount->Id->IBAN));
+            return new DTO\IbanAccount(new Iban((string) $xmlRelatedPartyTypeAccount->Id->IBAN, $this->ibanValidator));
         }
 
         if (isset($xmlRelatedPartyTypeAccount->Id->BBAN)) {

--- a/src/Camt054/Decoder/Message.php
+++ b/src/Camt054/Decoder/Message.php
@@ -57,7 +57,7 @@ class Message extends BaseMessageDecoder
     protected function getAccount(SimpleXMLElement $xmlRecord): Account
     {
         if (isset($xmlRecord->Acct->Id->IBAN)) {
-            return new DTO\IbanAccount(new Iban((string) $xmlRecord->Acct->Id->IBAN));
+            return new DTO\IbanAccount(new Iban((string) $xmlRecord->Acct->Id->IBAN, $this->ibanValidator));
         }
 
         if (isset($xmlRecord->Acct->Id->BBAN)) {

--- a/src/Decoder/EntryTransactionDetail.php
+++ b/src/Decoder/EntryTransactionDetail.php
@@ -8,6 +8,7 @@ use Genkgo\Camt\Decoder\Factory\DTO as DTOFactory;
 use Genkgo\Camt\DTO;
 use Genkgo\Camt\DTO\RelatedParty;
 use Genkgo\Camt\Util\MoneyFactory;
+use Iban\Validation\Validator;
 use SimpleXMLElement;
 
 abstract class EntryTransactionDetail
@@ -23,12 +24,18 @@ abstract class EntryTransactionDetail
     private $moneyFactory;
 
     /**
+     * @var Validator
+     */
+    protected $ibanValidator;
+
+    /**
      * EntryTransactionDetail constructor.
      */
     public function __construct(DateDecoderInterface $dateDecoder)
     {
         $this->dateDecoder = $dateDecoder;
         $this->moneyFactory = new MoneyFactory();
+        $this->ibanValidator = new Validator();
     }
 
     public function addReference(DTO\EntryTransactionDetail $detail, SimpleXMLElement $xmlDetail): void

--- a/src/Decoder/Message.php
+++ b/src/Decoder/Message.php
@@ -6,6 +6,7 @@ namespace Genkgo\Camt\Decoder;
 
 use Genkgo\Camt\Decoder\Factory\DTO as DTOFactory;
 use Genkgo\Camt\DTO;
+use Iban\Validation\Validator;
 use SimpleXMLElement;
 
 abstract class Message
@@ -21,12 +22,18 @@ abstract class Message
     protected $dateDecoder;
 
     /**
+     * @var Validator
+     */
+    protected $ibanValidator;
+
+    /**
      * Message constructor.
      */
     public function __construct(Record $recordDecoder, DateDecoderInterface $dateDecoder)
     {
         $this->recordDecoder = $recordDecoder;
         $this->dateDecoder = $dateDecoder;
+        $this->ibanValidator = new Validator();
     }
 
     public function addGroupHeader(DTO\Message $message, SimpleXMLElement $document): void

--- a/src/Iban.php
+++ b/src/Iban.php
@@ -15,11 +15,15 @@ class Iban
      */
     private $iban;
 
-    public function __construct(string $iban)
+    public function __construct(string $iban, ?Validator $ibanValidator = null)
     {
         $iban = new IbanDetails($iban);
 
-        if (!(new Validator())->validate($iban)) {
+        if ($ibanValidator === null) {
+            $ibanValidator = new Validator();
+        }
+
+        if ($ibanValidator->validate($iban) === false) {
             throw new InvalidArgumentException("Unknown IBAN {$iban}");
         }
 


### PR DESCRIPTION
We encountered a speed issue where if you have a lot of entries it creates an IBAN object for each IBAN found. The IBAN class creates a validator (external package) which reads a YAML file containing rules that is about 1200 lines. So if you, for example, have 700 IBANs that need to be validated, it needs to parse that file 700 times. Which causes slowdown.

This PR changes it so the validator is created once on the Message and once on the TransactionDetail and it will keep re-using that instead of creating a new Validator each time.