### PR TITLE
Fix: Register all default message formats

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -47,6 +47,7 @@ class Config
     {
         $config = new self();
         $config->addMessageFormat(new Camt052\MessageFormat\V01());
+        $config->addMessageFormat(new Camt052\MessageFormat\V02());
         $config->addMessageFormat(new Camt052\MessageFormat\V04());
         $config->addMessageFormat(new Camt052\MessageFormat\V06());
         $config->addMessageFormat(new Camt053\MessageFormat\V02());

--- a/test/Unit/ConfigTest.php
+++ b/test/Unit/ConfigTest.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace Genkgo\TestCamt\Unit;
 
+use Genkgo\Camt\Camt052;
+use Genkgo\Camt\Camt053;
+use Genkgo\Camt\Camt054;
 use Genkgo\Camt\Config;
+use Genkgo\Camt\MessageFormatInterface;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -12,6 +16,65 @@ use PHPUnit\Framework\TestCase;
  */
 class ConfigTest extends TestCase
 {
+    public function testDefaultConfigHasMessageFormats(): void
+    {
+        $config = Config::getDefault();
+
+        $messageFormats = $config->getMessageFormats();
+
+        $expectedMessageFormats = [
+            Camt052\MessageFormat\V01::class,
+            Camt052\MessageFormat\V02::class,
+            Camt052\MessageFormat\V04::class,
+            Camt052\MessageFormat\V06::class,
+            Camt053\MessageFormat\V02::class,
+            Camt053\MessageFormat\V03::class,
+            Camt053\MessageFormat\V04::class,
+            Camt054\MessageFormat\V02::class,
+            Camt054\MessageFormat\V04::class,
+        ];
+
+        $actualMessageFormats = array_map(static function (MessageFormatInterface $messageFormat): string {
+            return get_class($messageFormat);
+        }, $messageFormats);
+
+        $additionalMessageFormats = array_diff(
+            $actualMessageFormats,
+            $expectedMessageFormats
+        );
+
+        self::assertEmpty($additionalMessageFormats, sprintf(
+            <<<TXT
+Failed asserting that the default configuration does not configure additional message formats.
+
+Did you intend to add the following message formats?
+
+- %s
+
+TXT
+            ,
+            implode("\n- ", $additionalMessageFormats)
+        ));
+
+        $missingMessageFormats = array_diff(
+            $expectedMessageFormats,
+            $actualMessageFormats
+        );
+
+        self::assertEmpty($missingMessageFormats, sprintf(
+            <<<TXT
+Failed asserting that the default configuration configures all expected formats.
+
+Have you forgotten to add the following message formats?
+
+- %s
+
+TXT
+            ,
+            implode("\n- ", $missingMessageFormats)
+        ));
+    }
+
     public function testDefaultConfigHasXsdValidation(): void
     {
         $config = Config::getDefault();


### PR DESCRIPTION
This pull request

- [x] asserts that all currently available message formats are registered with `Config::getDefault()`
- [x] registers `Camt052\MessageFormat\V02` 