### PR TITLE
Fix: Remove `phpspec/prophecy-phpunit`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,6 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "@stable",
         "phpstan/phpstan": "@stable",
-        "phpunit/phpunit": "@stable",
-        "phpspec/prophecy-phpunit": "@stable"
+        "phpunit/phpunit": "@stable"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4f3622f4b6ddd5ddce15135cb8428bcf",
+    "content-hash": "4fa881be6c9b0fdda82c82c20e728b27",
     "packages": [
         {
             "name": "jschaedl/iban-validation",
@@ -1474,58 +1474,6 @@
                 "source": "https://github.com/phpspec/prophecy/tree/v1.15.0"
             },
             "time": "2021-12-08T12:19:24+00:00"
-        },
-        {
-            "name": "phpspec/prophecy-phpunit",
-            "version": "v2.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpspec/prophecy-phpunit.git",
-                "reference": "2d7a9df55f257d2cba9b1d0c0963a54960657177"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy-phpunit/zipball/2d7a9df55f257d2cba9b1d0c0963a54960657177",
-                "reference": "2d7a9df55f257d2cba9b1d0c0963a54960657177",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.3 || ^8",
-                "phpspec/prophecy": "^1.3",
-                "phpunit/phpunit": "^9.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Prophecy\\PhpUnit\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Christophe Coevoet",
-                    "email": "stof@notk.org"
-                }
-            ],
-            "description": "Integrating the Prophecy mocking library in PHPUnit test cases",
-            "homepage": "http://phpspec.net",
-            "keywords": [
-                "phpunit",
-                "prophecy"
-            ],
-            "support": {
-                "issues": "https://github.com/phpspec/prophecy-phpunit/issues",
-                "source": "https://github.com/phpspec/prophecy-phpunit/tree/v2.0.1"
-            },
-            "time": "2020-07-09T08:33:42+00:00"
         },
         {
             "name": "phpstan/phpstan",
@@ -4373,8 +4321,7 @@
     "stability-flags": {
         "friendsofphp/php-cs-fixer": 0,
         "phpstan/phpstan": 0,
-        "phpunit/phpunit": 0,
-        "phpspec/prophecy-phpunit": 0
+        "phpunit/phpunit": 0
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,13 +6,6 @@ parameters:
     inferPrivatePropertyTypeFromConstructor: true
     checkMissingIterableValueType: false
     ignoreErrors:
-        - '~^Call to an undefined method Prophecy\\Prophecy\\~'
-        -
-            message: '~^Parameter \#1 .* of class Genkgo\\Camt\\.* constructor expects Genkgo\\Camt\\.*, object given\.$~'
-            path: test
-        -
-            message: '~^Parameter \#1 .* of method Genkgo\\Camt\\.* expects Genkgo\\Camt\\.*, object given\.$~'
-            path: test
         -
             message: '~^Cannot call method .*\(\) on Genkgo\\Camt\\.*\|null\.$~'
             path: test

--- a/test/Unit/Camt052/Decoder/MessageTest.php
+++ b/test/Unit/Camt052/Decoder/MessageTest.php
@@ -9,17 +9,13 @@ use Genkgo\Camt\Camt052\Decoder\V01\Message;
 use Genkgo\Camt\Decoder as DecoderObject;
 use Genkgo\Camt\DTO;
 use Genkgo\TestCamt\AbstractTestCase;
-use Prophecy\Argument;
-use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
+use PHPUnit\Framework;
 use SimpleXMLElement;
 
 class MessageTest extends AbstractTestCase
 {
-    use ProphecyTrait;
-
     /**
-     * @var ObjectProphecy
+     * @var DecoderObject\Record&Framework\MockObject\MockObject
      */
     private $mockedRecordDecoder;
 
@@ -30,39 +26,53 @@ class MessageTest extends AbstractTestCase
 
     protected function setUp(): void
     {
-        $entry = $this->prophesize(DecoderObject\Entry::class);
-        $this->mockedRecordDecoder = $this
-            ->prophesize(DecoderObject\Record::class)
-            ->willBeConstructedWith([$entry->reveal(), new DecoderObject\Date()]);
-        $this->decoder = new Message($this->mockedRecordDecoder->reveal(), new DecoderObject\Date());
+        $this->mockedRecordDecoder = $this->createMock(DecoderObject\Record::class);
+        $this->decoder = new Message($this->mockedRecordDecoder, new DecoderObject\Date());
     }
 
     public function testItAddsGroupHeader(): void
     {
-        $message = $this->prophesize(DTO\Message::class);
-        $message->setGroupHeader(Argument::type(DTO\GroupHeader::class))->shouldBeCalled();
+        $message = $this->createMock(DTO\Message::class);
 
-        $this->decoder->addGroupHeader($message->reveal(), $this->getXmlMessage());
+        $message
+            ->expects(self::once())
+            ->method('setGroupHeader')
+            ->with(self::isInstanceOf(DTO\GroupHeader::class));
+
+        $this->decoder->addGroupHeader($message, $this->getXmlMessage());
     }
 
     public function testItAddsReports(): void
     {
-        $message = $this->prophesize(DTO\Message::class);
+        $message = $this->createMock(DTO\Message::class);
 
-        $this->mockedRecordDecoder->addBalances(
-            Argument::type(Camt052\DTO\Report::class),
-            Argument::type('\SimpleXMLElement')
-        )->shouldBeCalled();
-        $this->mockedRecordDecoder->addEntries(
-            Argument::type(Camt052\DTO\Report::class),
-            Argument::type('\SimpleXMLElement')
-        )->shouldBeCalled();
+        $this->mockedRecordDecoder
+            ->expects(self::once())
+            ->method('addBalances')
+            ->with(
+                self::isInstanceOf(Camt052\DTO\Report::class),
+                self::isInstanceOf(SimpleXMLElement::class)
+            );
 
-        $message->setRecords(Argument::that(function ($argument): bool {
-            return is_array($argument) && $argument[0] instanceof Camt052\DTO\Report;
-        }))->shouldBeCalled();
+        $this->mockedRecordDecoder
+            ->expects(self::once())
+            ->method('addEntries')
+            ->with(
+                self::isInstanceOf(Camt052\DTO\Report::class),
+                self::isInstanceOf(SimpleXMLElement::class)
+            );
 
-        $this->decoder->addRecords($message->reveal(), $this->getXmlMessage());
+        $message
+            ->expects(self::once())
+            ->method('setRecords')
+            ->with(self::callback(static function (array $records): bool {
+                self::assertContainsOnlyInstancesOf(Camt052\DTO\Report::class, $records);
+                self::assertCount(1, $records);
+
+                return true;
+            }));
+
+        $this->decoder->addRecords($message, $this->getXmlMessage());
     }
 
     private function getXmlMessage(): SimpleXMLElement

--- a/test/Unit/Camt053/Decoder/MessageTest.php
+++ b/test/Unit/Camt053/Decoder/MessageTest.php
@@ -9,17 +9,13 @@ use Genkgo\Camt\Camt053\Decoder\Message;
 use Genkgo\Camt\Decoder as DecoderObject;
 use Genkgo\Camt\DTO;
 use Genkgo\TestCamt\AbstractTestCase;
-use Prophecy\Argument;
-use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
+use PHPUnit\Framework;
 use SimpleXMLElement;
 
 class MessageTest extends AbstractTestCase
 {
-    use ProphecyTrait;
-
     /**
-     * @var ObjectProphecy
+     * @var DecoderObject\Record&Framework\MockObject\MockObject
      */
     private $mockedRecordDecoder;
 
@@ -30,39 +26,53 @@ class MessageTest extends AbstractTestCase
 
     protected function setUp(): void
     {
-        $entry = $this->prophesize(DecoderObject\Entry::class);
-        $this->mockedRecordDecoder = $this
-            ->prophesize(DecoderObject\Record::class)
-            ->willBeConstructedWith([$entry->reveal(), new DecoderObject\Date()]);
-        $this->decoder = new Message($this->mockedRecordDecoder->reveal(), new DecoderObject\Date());
+        $this->mockedRecordDecoder = $this->createMock(DecoderObject\Record::class);
+        $this->decoder = new Message($this->mockedRecordDecoder, new DecoderObject\Date());
     }
 
     public function testItAddsGroupHeader(): void
     {
-        $message = $this->prophesize(DTO\Message::class);
-        $message->setGroupHeader(Argument::type(DTO\GroupHeader::class))->shouldBeCalled();
+        $message = $this->createMock(DTO\Message::class);
 
-        $this->decoder->addGroupHeader($message->reveal(), $this->getXmlMessage());
+        $message
+            ->expects(self::once())
+            ->method('setGroupHeader')
+            ->with(self::isInstanceOf(DTO\GroupHeader::class));
+
+        $this->decoder->addGroupHeader($message, $this->getXmlMessage());
     }
 
     public function testItAddsStatements(): void
     {
-        $message = $this->prophesize(DTO\Message::class);
+        $message = $this->createMock(DTO\Message::class);
 
-        $this->mockedRecordDecoder->addBalances(
-            Argument::type(Camt053\DTO\Statement::class),
-            Argument::type('\SimpleXMLElement')
-        )->shouldBeCalled();
-        $this->mockedRecordDecoder->addEntries(
-            Argument::type(Camt053\DTO\Statement::class),
-            Argument::type('\SimpleXMLElement')
-        )->shouldBeCalled();
+        $this->mockedRecordDecoder
+            ->expects(self::once())
+            ->method('addBalances')
+            ->with(
+                self::isInstanceOf(Camt053\DTO\Statement::class),
+                self::isInstanceOf(SimpleXMLElement::class)
+            );
 
-        $message->setRecords(Argument::that(function ($argument): bool {
-            return is_array($argument) && $argument[0] instanceof Camt053\DTO\Statement;
-        }))->shouldBeCalled();
+        $this->mockedRecordDecoder
+            ->expects(self::once())
+            ->method('addEntries')
+            ->with(
+                self::isInstanceOf(Camt053\DTO\Statement::class),
+                self::isInstanceOf(SimpleXMLElement::class)
+            );
 
-        $this->decoder->addRecords($message->reveal(), $this->getXmlMessage());
+        $message
+            ->expects(self::once())
+            ->method('setRecords')
+            ->with(self::callback(static function (array $records): bool {
+                self::assertContainsOnlyInstancesOf(Camt053\DTO\Statement::class, $records);
+                self::assertCount(1, $records);
+
+                return true;
+            }));
+
+        $this->decoder->addRecords($message, $this->getXmlMessage());
     }
 
     private function getXmlMessage(): SimpleXMLElement

--- a/test/Unit/Camt054/Decoder/MessageTest.php
+++ b/test/Unit/Camt054/Decoder/MessageTest.php
@@ -9,17 +9,13 @@ use Genkgo\Camt\Camt054\Decoder\Message;
 use Genkgo\Camt\Decoder as DecoderObject;
 use Genkgo\Camt\DTO;
 use Genkgo\TestCamt\AbstractTestCase;
-use Prophecy\Argument;
-use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
+use PHPUnit\Framework;
 use SimpleXMLElement;
 
 class MessageTest extends AbstractTestCase
 {
-    use ProphecyTrait;
-
     /**
-     * @var ObjectProphecy
+     * @var DecoderObject\Record&Framework\MockObject\MockObject
      */
     private $mockedRecordDecoder;
 
@@ -30,35 +26,45 @@ class MessageTest extends AbstractTestCase
 
     protected function setUp(): void
     {
-        $entry = $this->prophesize(DecoderObject\Entry::class);
-        $this->mockedRecordDecoder = $this
-            ->prophesize(DecoderObject\Record::class)
-            ->willBeConstructedWith([$entry->reveal(), new DecoderObject\Date()]);
-        $this->decoder = new Message($this->mockedRecordDecoder->reveal(), new DecoderObject\Date());
+        $this->mockedRecordDecoder = $this->createMock(DecoderObject\Record::class);
+        $this->decoder = new Message($this->mockedRecordDecoder, new DecoderObject\Date());
     }
 
     public function testItAddsGroupHeader(): void
     {
-        $message = $this->prophesize(DTO\Message::class);
-        $message->setGroupHeader(Argument::type(DTO\GroupHeader::class))->shouldBeCalled();
+        $message = $this->createMock(DTO\Message::class);
 
-        $this->decoder->addGroupHeader($message->reveal(), $this->getXmlMessage());
+        $message
+            ->expects(self::once())
+            ->method('setGroupHeader')
+            ->with(self::isInstanceOf(DTO\GroupHeader::class));
+
+        $this->decoder->addGroupHeader($message, $this->getXmlMessage());
     }
 
     public function testItAddsNotifications(): void
     {
-        $message = $this->prophesize(DTO\Message::class);
+        $message = $this->createMock(DTO\Message::class);
 
-        $this->mockedRecordDecoder->addEntries(
-            Argument::type(Camt054\DTO\Notification::class),
-            Argument::type('\SimpleXMLElement')
-        )->shouldBeCalled();
+        $this->mockedRecordDecoder
+            ->expects(self::once())
+            ->method('addEntries')
+            ->with(
+                self::isInstanceOf(Camt054\DTO\Notification::class),
+                self::isInstanceOf(SimpleXMLElement::class),
+            );
 
-        $message->setRecords(Argument::that(function ($argument): bool {
-            return is_array($argument) && $argument[0] instanceof Camt054\DTO\Notification;
-        }))->shouldBeCalled();
+        $message
+            ->expects(self::once())
+            ->method('setRecords')
+            ->with(self::callback(static function (array $records): bool {
+                self::assertContainsOnlyInstancesOf(Camt054\DTO\Notification::class, $records);
+                self::assertCount(1, $records);
 
-        $this->decoder->addRecords($message->reveal(), $this->getXmlMessage());
+                return true;
+            }));
+
+        $this->decoder->addRecords($message, $this->getXmlMessage());
     }
 
     private function getXmlMessage(): SimpleXMLElement

--- a/test/Unit/Decoder/EntryTest.php
+++ b/test/Unit/Decoder/EntryTest.php
@@ -7,17 +7,13 @@ namespace Genkgo\TestCamt\Unit\Decoder;
 use Genkgo\Camt\Decoder;
 use Genkgo\Camt\DTO;
 use Genkgo\TestCamt\AbstractTestCase;
-use Prophecy\Argument;
-use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
+use PHPUnit\Framework;
 use SimpleXMLElement;
 
 class EntryTest extends AbstractTestCase
 {
-    use ProphecyTrait;
-
     /**
-     * @var ObjectProphecy
+     * @var Decoder\EntryTransactionDetail&Framework\MockObject\MockObject
      */
     private $mockedEntryTransactionDetailDecoder;
 
@@ -28,71 +24,122 @@ class EntryTest extends AbstractTestCase
 
     protected function setUp(): void
     {
-        $this->mockedEntryTransactionDetailDecoder = $this->prophesize(Decoder\EntryTransactionDetail::class);
-        $this->decoder = new Decoder\Entry($this->mockedEntryTransactionDetailDecoder->reveal());
+        $this->mockedEntryTransactionDetailDecoder = $this->createMock(Decoder\EntryTransactionDetail::class);
+        $this->decoder = new Decoder\Entry($this->mockedEntryTransactionDetailDecoder);
     }
 
     public function testItDoesNotAddTransactionDetailsIfThereIsNoneInXml(): void
     {
-        $entry = $this->prophesize(DTO\Entry::class);
-        $entry->addTransactionDetail(Argument::any())->shouldNotBeCalled();
+        $entry = $this->createMock(DTO\Entry::class);
+
+        $entry
+            ->expects(self::never())
+            ->method('addTransactionDetail')
+            ->with(self::anything());
 
         $xmlEntry = new SimpleXMLElement('<content></content>');
-        $this->decoder->addTransactionDetails($entry->reveal(), $xmlEntry);
+        $this->decoder->addTransactionDetails($entry, $xmlEntry);
     }
 
     public function testItAddsTransactionDetailsIfThereArePresentInXml(): void
     {
-        $entry = $this->prophesize(DTO\Entry::class);
-        $this->mockedEntryTransactionDetailDecoder->addReference(
-            Argument::type(DTO\EntryTransactionDetail::class),
-            Argument::type('\SimpleXMLElement')
-        )->shouldBeCalled();
-        $this->mockedEntryTransactionDetailDecoder->addRelatedParties(
-            Argument::type(DTO\EntryTransactionDetail::class),
-            Argument::type('\SimpleXMLElement')
-        )->shouldBeCalled();
-        $this->mockedEntryTransactionDetailDecoder->addRelatedAgents(
-            Argument::type(DTO\EntryTransactionDetail::class),
-            Argument::type('\SimpleXMLElement')
-        )->shouldBeCalled();
-        $this->mockedEntryTransactionDetailDecoder->addRemittanceInformation(
-            Argument::type(DTO\EntryTransactionDetail::class),
-            Argument::type('\SimpleXMLElement')
-        )->shouldBeCalled();
-        $this->mockedEntryTransactionDetailDecoder->addRelatedDates(
-            Argument::type(DTO\EntryTransactionDetail::class),
-            Argument::type('\SimpleXMLElement')
-        )->shouldBeCalled();
-        $this->mockedEntryTransactionDetailDecoder->addReturnInformation(
-            Argument::type(DTO\EntryTransactionDetail::class),
-            Argument::type('\SimpleXMLElement')
-        )->shouldBeCalled();
-        $this->mockedEntryTransactionDetailDecoder->addAdditionalTransactionInformation(
-            Argument::type(DTO\EntryTransactionDetail::class),
-            Argument::type('\SimpleXMLElement')
-        )->shouldBeCalled();
-        $this->mockedEntryTransactionDetailDecoder->addBankTransactionCode(
-            Argument::type(DTO\EntryTransactionDetail::class),
-            Argument::type('\SimpleXMLElement')
-        )->shouldBeCalled();
-        $this->mockedEntryTransactionDetailDecoder->addCharges(
-            Argument::type(DTO\EntryTransactionDetail::class),
-            Argument::type('\SimpleXMLElement')
-        )->shouldBeCalled();
-        $this->mockedEntryTransactionDetailDecoder->addAmountDetails(
-            Argument::type(DTO\EntryTransactionDetail::class),
-            Argument::type('\SimpleXMLElement'),
-            Argument::type('\SimpleXMLElement')
-        )->shouldBeCalled();
-        $this->mockedEntryTransactionDetailDecoder->addAmount(
-            Argument::type(DTO\EntryTransactionDetail::class),
-            Argument::type('\SimpleXMLElement'),
-            Argument::type('\SimpleXMLElement')
-        )->shouldBeCalled();
-        $entry->addTransactionDetail(Argument::type(DTO\EntryTransactionDetail::class))->shouldBeCalled();
+        $entry = $this->createMock(DTO\Entry::class);
 
-        $this->decoder->addTransactionDetails($entry->reveal(), $this->getXmlEntry());
+        $this->mockedEntryTransactionDetailDecoder
+            ->expects(self::once())
+            ->method('addReference')
+            ->with(
+                self::isInstanceOf(DTO\EntryTransactionDetail::class),
+                self::isInstanceOf(SimpleXMLElement::class)
+            );
+
+        $this->mockedEntryTransactionDetailDecoder
+            ->expects(self::once())
+            ->method('addRelatedParties')
+            ->with(
+                self::isInstanceOf(DTO\EntryTransactionDetail::class),
+                self::isInstanceOf(SimpleXMLElement::class),
+            );
+
+        $this->mockedEntryTransactionDetailDecoder
+            ->expects(self::once())
+            ->method('addRelatedAgents')
+            ->with(
+                self::isInstanceOf(DTO\EntryTransactionDetail::class),
+                self::isInstanceOf(SimpleXMLElement::class),
+            );
+
+        $this->mockedEntryTransactionDetailDecoder
+            ->expects(self::once())
+            ->method('addRemittanceInformation')
+            ->with(
+                self::isInstanceOf(DTO\EntryTransactionDetail::class),
+                self::isInstanceOf(SimpleXMLElement::class),
+            );
+
+        $this->mockedEntryTransactionDetailDecoder
+            ->expects(self::once())
+            ->method('addRelatedDates')
+            ->with(
+                self::isInstanceOf(DTO\EntryTransactionDetail::class),
+                self::isInstanceOf(SimpleXMLElement::class),
+            );
+
+        $this->mockedEntryTransactionDetailDecoder
+            ->expects(self::once())
+            ->method('addReturnInformation')
+            ->with(
+                self::isInstanceOf(DTO\EntryTransactionDetail::class),
+                self::isInstanceOf(SimpleXMLElement::class),
+            );
+
+        $this->mockedEntryTransactionDetailDecoder
+            ->expects(self::once())
+            ->method('addAdditionalTransactionInformation')
+            ->with(
+                self::isInstanceOf(DTO\EntryTransactionDetail::class),
+                self::isInstanceOf(SimpleXMLElement::class),
+            );
+
+        $this->mockedEntryTransactionDetailDecoder
+            ->expects(self::once())
+            ->method('addBankTransactionCode')
+            ->with(
+                self::isInstanceOf(DTO\EntryTransactionDetail::class),
+                self::isInstanceOf(SimpleXMLElement::class),
+            );
+
+        $this->mockedEntryTransactionDetailDecoder
+            ->expects(self::once())
+            ->method('addCharges')
+            ->with(
+                self::isInstanceOf(DTO\EntryTransactionDetail::class),
+                self::isInstanceOf(SimpleXMLElement::class),
+            );
+
+        $this->mockedEntryTransactionDetailDecoder
+            ->expects(self::once())
+            ->method('addAmountDetails')
+            ->with(
+                self::isInstanceOf(DTO\EntryTransactionDetail::class),
+                self::isInstanceOf(SimpleXMLElement::class),
+            );
+
+        $this->mockedEntryTransactionDetailDecoder
+            ->expects(self::once())
+            ->method('addAmount')
+            ->with(
+                self::isInstanceOf(DTO\EntryTransactionDetail::class),
+                self::isInstanceOf(SimpleXMLElement::class),
+                self::isInstanceOf(SimpleXMLElement::class),
+            );
+
+        $entry
+            ->expects(self::once())
+            ->method('addTransactionDetail')
+            ->with(self::isInstanceOf(DTO\EntryTransactionDetail::class));
+
+        $this->decoder->addTransactionDetails($entry, $this->getXmlEntry());
     }
 
     private function getXmlEntry(): SimpleXMLElement

--- a/test/Unit/Decoder/EntryTransactionDetailTest.php
+++ b/test/Unit/Decoder/EntryTransactionDetailTest.php
@@ -9,162 +9,223 @@ use Genkgo\Camt\Decoder\Date;
 use Genkgo\Camt\DTO;
 use Genkgo\TestCamt\AbstractTestCase;
 use Money\Money;
-use Prophecy\Argument;
-use Prophecy\PhpUnit\ProphecyTrait;
 use SimpleXMLElement;
 
 class EntryTransactionDetailTest extends AbstractTestCase
 {
-    use ProphecyTrait;
-
     public function testItDoesNotAddReferenceIfThereIsNoneInXml(): void
     {
-        $detail = $this->prophesize(DTO\EntryTransactionDetail::class);
-        $detail->setReference(Argument::any())->shouldNotBeCalled();
+        $detail = $this->createMock(DTO\EntryTransactionDetail::class);
+
+        $detail
+            ->expects(self::never())
+            ->method('setReference')
+            ->with(self::anything());
 
         $xmlDetail = new SimpleXMLElement('<content></content>');
-        (new Camt053\Decoder\EntryTransactionDetail(new Date()))->addReference($detail->reveal(), $xmlDetail);
+        (new Camt053\Decoder\EntryTransactionDetail(new Date()))->addReference($detail, $xmlDetail);
     }
 
     public function testItAddsReferenceIfItIsPresentInXml(): void
     {
-        $detail = $this->prophesize(DTO\EntryTransactionDetail::class);
-        $detail->setReference(Argument::type(DTO\Reference::class))->shouldBeCalled();
+        $detail = $this->createMock(DTO\EntryTransactionDetail::class);
 
-        (new Camt053\Decoder\EntryTransactionDetail(new Date()))->addReference($detail->reveal(), $this->getXmlDetail());
+        $detail
+            ->expects(self::once())
+            ->method('setReference')
+            ->with(self::isInstanceOf(DTO\Reference::class));
+
+        (new Camt053\Decoder\EntryTransactionDetail(new Date()))->addReference($detail, $this->getXmlDetail());
     }
 
     public function testItDoesNotAddAdditionalTransactionInformationIfThereIsNoneInXml(): void
     {
-        $detail = $this->prophesize(DTO\EntryTransactionDetail::class);
-        $detail->setAdditionalTransactionInformation(Argument::any())->shouldNotBeCalled();
+        $detail = $this->createMock(DTO\EntryTransactionDetail::class);
+
+        $detail
+            ->expects(self::never())
+            ->method('setAdditionalTransactionInformation')
+            ->with(self::anything());
 
         $xmlDetail = new SimpleXMLElement('<content></content>');
-        (new Camt053\Decoder\EntryTransactionDetail(new Date()))->addAdditionalTransactionInformation($detail->reveal(), $xmlDetail);
+        (new Camt053\Decoder\EntryTransactionDetail(new Date()))->addAdditionalTransactionInformation($detail, $xmlDetail);
     }
 
     public function testItAddsAdditionalTransactionInformationIfItIsPresentInXml(): void
     {
-        $detail = $this->prophesize(DTO\EntryTransactionDetail::class);
-        $detail->setAdditionalTransactionInformation(
-            Argument::type(DTO\AdditionalTransactionInformation::class)
-        )->shouldBeCalled();
+        $detail = $this->createMock(DTO\EntryTransactionDetail::class);
 
-        (new Camt053\Decoder\EntryTransactionDetail(new Date()))->addAdditionalTransactionInformation($detail->reveal(), $this->getXmlDetail());
+        $detail
+            ->expects(self::once())
+            ->method('setAdditionalTransactionInformation')
+            ->with(self::isInstanceOf(DTO\AdditionalTransactionInformation::class));
+
+        (new Camt053\Decoder\EntryTransactionDetail(new Date()))->addAdditionalTransactionInformation($detail, $this->getXmlDetail());
     }
 
     public function testItDoesNotAddRemittanceInformationIfThereIsNoneInXml(): void
     {
-        $detail = $this->prophesize(DTO\EntryTransactionDetail::class);
-        $detail->setRemittanceInformation(Argument::any())->shouldNotBeCalled();
+        $detail = $this->createMock(DTO\EntryTransactionDetail::class);
+
+        $detail
+            ->expects(self::never())
+            ->method('setRemittanceInformation')
+            ->with(self::anything());
 
         $xmlDetail = new SimpleXMLElement('<content></content>');
-        (new Camt053\Decoder\EntryTransactionDetail(new Date()))->addRemittanceInformation($detail->reveal(), $xmlDetail);
+        (new Camt053\Decoder\EntryTransactionDetail(new Date()))->addRemittanceInformation($detail, $xmlDetail);
     }
 
     public function testItAddsRemittanceInformationAndCreditorReferenceIfItIsPresentInXml(): void
     {
-        $detail = $this->prophesize(DTO\EntryTransactionDetail::class);
-        $detail->setRemittanceInformation(Argument::type(DTO\RemittanceInformation::class))->shouldBeCalled();
+        $detail = $this->createMock(DTO\EntryTransactionDetail::class);
 
-        (new Camt053\Decoder\EntryTransactionDetail(new Date()))->addRemittanceInformation($detail->reveal(), $this->getXmlDetail());
+        $detail
+            ->expects(self::once())
+            ->method('setRemittanceInformation')
+            ->with(self::isInstanceOf(DTO\RemittanceInformation::class));
+
+        (new Camt053\Decoder\EntryTransactionDetail(new Date()))->addRemittanceInformation($detail, $this->getXmlDetail());
     }
 
     public function testItAddsRemittanceInformationIfItIsPresentInXml(): void
     {
-        $detail = $this->prophesize(DTO\EntryTransactionDetail::class);
-        $detail->setRemittanceInformation(Argument::type(DTO\RemittanceInformation::class))->shouldBeCalled();
+        $detail = $this->createMock(DTO\EntryTransactionDetail::class);
+
+        $detail
+            ->expects(self::once())
+            ->method('setRemittanceInformation')
+            ->with(self::isInstanceOf(DTO\RemittanceInformation::class));
 
         $xmlDetail = new SimpleXMLElement('<content><RmtInf><Ustrd>Lorem</Ustrd></RmtInf></content>');
-        (new Camt053\Decoder\EntryTransactionDetail(new Date()))->addRemittanceInformation($detail->reveal(), $xmlDetail);
+
+        (new Camt053\Decoder\EntryTransactionDetail(new Date()))->addRemittanceInformation($detail, $xmlDetail);
     }
 
     public function testItDoesNotAddReturnInformationIfThereIsNoneInXml(): void
     {
-        $detail = $this->prophesize(DTO\EntryTransactionDetail::class);
-        $detail->setReturnInformation(Argument::any())->shouldNotBeCalled();
+        $detail = $this->createMock(DTO\EntryTransactionDetail::class);
+
+        $detail
+            ->expects(self::never())
+            ->method('setReturnInformation')
+            ->with(self::anything());
 
         $xmlDetail = new SimpleXMLElement('<content></content>');
-        (new Camt053\Decoder\EntryTransactionDetail(new Date()))->addReturnInformation($detail->reveal(), $xmlDetail);
+        (new Camt053\Decoder\EntryTransactionDetail(new Date()))->addReturnInformation($detail, $xmlDetail);
     }
 
     public function testItAddsReturnInformationIfItIsPresentInXml(): void
     {
-        $detail = $this->prophesize(DTO\EntryTransactionDetail::class);
-        $detail->setReturnInformation(
-            Argument::type(DTO\ReturnInformation::class)
-        )->shouldBeCalled();
+        $detail = $this->createMock(DTO\EntryTransactionDetail::class);
 
-        (new Camt053\Decoder\EntryTransactionDetail(new Date()))->addReturnInformation($detail->reveal(), $this->getXmlDetail());
+        $detail
+            ->expects(self::once())
+            ->method('setReturnInformation')
+            ->with(self::isInstanceOf(DTO\ReturnInformation::class));
+
+        (new Camt053\Decoder\EntryTransactionDetail(new Date()))->addReturnInformation($detail, $this->getXmlDetail());
     }
 
     public function testItDoesNotAddRelatedPartiesIfThereIsNoneInXml(): void
     {
-        $detail = $this->prophesize(DTO\EntryTransactionDetail::class);
-        $detail->addRelatedParty(Argument::any())->shouldNotBeCalled();
+        $detail = $this->createMock(DTO\EntryTransactionDetail::class);
+
+        $detail
+            ->expects(self::never())
+            ->method('addRelatedParty')
+            ->with(self::anything());
 
         $xmlDetail = new SimpleXMLElement('<content></content>');
-        (new Camt053\Decoder\EntryTransactionDetail(new Date()))->addRelatedParties($detail->reveal(), $xmlDetail);
+        (new Camt053\Decoder\EntryTransactionDetail(new Date()))->addRelatedParties($detail, $xmlDetail);
     }
 
     public function testItAddsRelatedPartiesIfIsPresentInXml(): void
     {
-        $detail = $this->prophesize(DTO\EntryTransactionDetail::class);
-        $detail->addRelatedParty(Argument::type(DTO\RelatedParty::class))->shouldBeCalled();
+        $detail = $this->createMock(DTO\EntryTransactionDetail::class);
 
-        (new Camt053\Decoder\EntryTransactionDetail(new Date()))->addRelatedParties($detail->reveal(), $this->getXmlDetail());
+        $detail
+            ->expects(self::once())
+            ->method('addRelatedParty')
+            ->with(self::isInstanceOf(DTO\RelatedParty::class));
+
+        (new Camt053\Decoder\EntryTransactionDetail(new Date()))->addRelatedParties($detail, $this->getXmlDetail());
     }
 
     public function testItDoesNotAddRelatedDatesIfThereIsNoneInXml(): void
     {
-        $detail = $this->prophesize(DTO\EntryTransactionDetail::class);
-        $detail->setRelatedDates(Argument::any())->shouldNotBeCalled();
+        $detail = $this->createMock(DTO\EntryTransactionDetail::class);
+
+        $detail
+            ->expects(self::never())
+            ->method('setRelatedDates')
+            ->with(self::anything());
 
         $xmlDetail = new SimpleXMLElement('<content></content>');
-        (new Camt053\Decoder\EntryTransactionDetail(new Date()))->addRelatedDates($detail->reveal(), $xmlDetail);
+        (new Camt053\Decoder\EntryTransactionDetail(new Date()))->addRelatedDates($detail, $xmlDetail);
     }
 
     public function testItAddsRelatedDatesIfIsPresentInXml(): void
     {
-        $detail = $this->prophesize(DTO\EntryTransactionDetail::class);
-        $detail->setRelatedDates(Argument::type(DTO\RelatedDates::class))->shouldBeCalled();
+        $detail = $this->createMock(DTO\EntryTransactionDetail::class);
 
-        (new Camt053\Decoder\EntryTransactionDetail(new Date()))->addRelatedDates($detail->reveal(), $this->getXmlDetail());
+        $detail
+            ->expects(self::once())
+            ->method('setRelatedDates')
+            ->with(self::isInstanceOf(DTO\RelatedDates::class));
+
+        (new Camt053\Decoder\EntryTransactionDetail(new Date()))->addRelatedDates($detail, $this->getXmlDetail());
     }
 
     public function testItDoesNotAddChargesIfThereIsNoneInXml(): void
     {
-        $detail = $this->prophesize(DTO\EntryTransactionDetail::class);
-        $detail->setCharges(Argument::any())->shouldNotBeCalled();
+        $detail = $this->createMock(DTO\EntryTransactionDetail::class);
+
+        $detail
+            ->expects(self::never())
+            ->method('setCharges')
+            ->with(self::anything());
 
         $xmlDetail = new SimpleXMLElement('<content></content>');
-        (new Camt053\Decoder\EntryTransactionDetail(new Date()))->addCharges($detail->reveal(), $xmlDetail);
+        (new Camt053\Decoder\EntryTransactionDetail(new Date()))->addCharges($detail, $xmlDetail);
     }
 
     public function testItAddsChargesIfIsPresentInXml(): void
     {
-        $detail = $this->prophesize(DTO\EntryTransactionDetail::class);
-        $detail->setCharges(Argument::type(DTO\Charges::class))->shouldBeCalled();
+        $detail = $this->createMock(DTO\EntryTransactionDetail::class);
 
-        (new Camt053\Decoder\EntryTransactionDetail(new Date()))->addCharges($detail->reveal(), $this->getXmlDetail());
+        $detail
+            ->expects(self::once())
+            ->method('setCharges')
+            ->with(self::isInstanceOf(DTO\Charges::class));
+
+        (new Camt053\Decoder\EntryTransactionDetail(new Date()))->addCharges($detail, $this->getXmlDetail());
     }
 
     public function testItAddsAmountDetailsIfIsPresentInXmsl(): void
     {
-        $detail = $this->prophesize(DTO\EntryTransactionDetail::class);
-        $detail->setAmountDetails(Argument::type(Money::class))->shouldBeCalled();
+        $detail = $this->createMock(DTO\EntryTransactionDetail::class);
+
+        $detail
+            ->expects(self::once())
+            ->method('setAmountDetails')
+            ->with(self::isInstanceOf(Money::class));
 
         $CdtDbtInd = new SimpleXMLElement('<content>DBIT</content>');
-        (new Camt053\Decoder\EntryTransactionDetail(new Date()))->addAmountDetails($detail->reveal(), $this->getXmlDetail(), $CdtDbtInd);
+        (new Camt053\Decoder\EntryTransactionDetail(new Date()))->addAmountDetails($detail, $this->getXmlDetail(), $CdtDbtInd);
     }
 
     public function testItAddsAmountIfIsPresentInXmsl(): void
     {
-        $detail = $this->prophesize(DTO\EntryTransactionDetail::class);
-        $detail->setAmount(Argument::type(Money::class))->shouldBeCalled();
+        $detail = $this->createMock(DTO\EntryTransactionDetail::class);
+
+        $detail
+            ->expects(self::once())
+            ->method('setAmount')
+            ->with(self::isInstanceOf(Money::class));
 
         $CdtDbtInd = new SimpleXMLElement('<content>DBIT</content>');
-        (new Camt053\Decoder\EntryTransactionDetail(new Date()))->addAmount($detail->reveal(), $this->getXmlDetail(), $CdtDbtInd);
+        (new Camt053\Decoder\EntryTransactionDetail(new Date()))->addAmount($detail, $this->getXmlDetail(), $CdtDbtInd);
     }
 
     private function getXmlDetail(): SimpleXMLElement


### PR DESCRIPTION
This pull request

- [x] stops using `phpspec/prophecy` and removes `phpspec/prophecy-phpunit`