### PR TITLE
Add new standard as not supported in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Library to read CAMT files. Currently only CAMT.052, CAMT.053 and CAMT.054 are s
 | camt.052.001.04   | :heavy_check_mark: |
 | camt.052.001.05   |                    |
 | camt.052.001.06   | :heavy_check_mark: |
+| camt.052.001.08   |                    |
 
 #### Camt 053
 
@@ -32,6 +33,7 @@ Library to read CAMT files. Currently only CAMT.052, CAMT.053 and CAMT.054 are s
 | camt.053.001.04   | :heavy_check_mark: |
 | camt.053.001.05   |                    |
 | camt.053.001.06   |                    |
+| camt.053.001.08   |                    |
 
 #### Camt 054
 
@@ -43,7 +45,7 @@ Library to read CAMT files. Currently only CAMT.052, CAMT.053 and CAMT.054 are s
 | camt.054.001.04   | :heavy_check_mark: |
 | camt.054.001.05   |                    |
 | camt.054.001.06   |                    |
-
+| camt.054.001.08   |                    |
 
 ### Installation
 


### PR DESCRIPTION
New standards 2022 are not supported by the library

![image](https://user-images.githubusercontent.com/646632/211844079-df18c21d-16de-480e-9c31-71e50ef86e93.png)


https://www.six-group.com/dam/download/banking-services/interbank-clearing/de/standardization/consultation/sps-2022-high-level-information-de.pdf 

https://www.six-group.com/dam/download/banking-services/interbank-clearing/fr/standardization/consultation/sps-2022-high-level-information-fr.pdf