### PR TITLE
Enhancement: Enable `no_trailing_comma_in_singleline` fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -125,8 +125,7 @@ return (new PhpCsFixer\Config())
         'no_spaces_inside_parenthesis' => true,
         'no_superfluous_elseif' => true,
         'no_superfluous_phpdoc_tags' => ['allow_mixed' => true],
-        'no_trailing_comma_in_list_call' => true,
-        'no_trailing_comma_in_singleline_array' => true,
+        'no_trailing_comma_in_singleline' => true,
         'no_trailing_whitespace' => true,
         'no_trailing_whitespace_in_comment' => true,
         'no_trailing_whitespace_in_string' => false, // Too dangerous


### PR DESCRIPTION
This pull request

- [x] enables the `no_trailing_comma_in_singleline` fixer instead of the deprecated `no_trailing_comma_in_list_call` and `no_trailing_comma_in_singleline_array` fixers

💁‍♂️ Running

```shell
vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php --diff --verbose
```

on current `master` yields

```
PHP CS Fixer 3.14.3 Oliva by Fabien Potencier and Dariusz Ruminski.
PHP runtime: 8.1.14
Loaded config default from ".php-cs-fixer.dist.php".
Using cache file "/var/folders/lz/j7s9n1kx4lnbpz098_wg6kbw0000gn/T/php-cs-fixer-Users-am-Sites-genkgo-camt".
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS                                                                                                                                                                                                    106 / 106 (100%)
Legend: .-no changes, F-fixed, S-skipped (cached or empty file), I-invalid file syntax (file ignored), E-error

Fixed 0 of 106 files in 0.003 seconds, 14.000 MB memory used

Detected deprecations in use:
- Rule "no_trailing_comma_in_list_call" is deprecated. Use "no_trailing_comma_in_singleline" instead.
- Rule "no_trailing_comma_in_singleline_array" is deprecated. Use "no_trailing_comma_in_singleline" instead.
```

For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.14.3/doc/rules/basic/no_trailing_comma_in_singleline.rst.