### PR TITLE
Fix: Migrate configuration for phpunit/phpunit

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,17 +1,19 @@
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         colors="true"
-         verbose="true"
-         backupGlobals="false"
-         beStrictAboutOutputDuringTests="true"
-         beStrictAboutTestsThatDoNotTestAnything="true"
+<?xml version="1.0"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    backupGlobals="false"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    colors="true"
+    verbose="true"
 >
+    <coverage includeUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </coverage>
     <testsuite name="GenkgoMail tests">
         <directory>./test/Unit</directory>
     </testsuite>
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
 </phpunit>


### PR DESCRIPTION
This pull request

- [x] migrates the configuration for `phpunit/phpunit`

💁‍♂️ Running

```shell
vendor/bin/phpunit --configuration=phpunit.xml
```

on current `master` yields

```shell
PHPUnit 9.6.3 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.1.14
Configuration: phpunit.xml
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

.............................................................     61 / 61 (100%)

Time: 00:00.129, Memory: 8.00 MB

OK (61 tests, 551 assertions)
```