### PR TITLE
Enhancement: Enable `php_unit_data_provider_static` fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -154,6 +154,7 @@ return (new PhpCsFixer\Config())
         'ordered_interfaces' => true,
         'ordered_traits' => true,
         'php_unit_construct' => true,
+        'php_unit_data_provider_static' => true,
         'php_unit_dedicate_assert' => true,
         'php_unit_dedicate_assert_internal_type' => true,
         'php_unit_expectation' => true,

--- a/test/Util/MoneyFactoryTest.php
+++ b/test/Util/MoneyFactoryTest.php
@@ -25,7 +25,7 @@ class MoneyFactoryTest extends TestCase
         self::assertTrue($actual->equals($expected));
     }
 
-    public function providerCreate(): array
+    public static function providerCreate(): array
     {
         return [
             ['<Amt Ccy="CHF">27.50</Amt>', null, Money::CHF(2750)],


### PR DESCRIPTION
This pull request

- [x] enables the `php_unit_data_provider_static` fixer
- [x] runs `vendor/bin/php-cs-fixer fix`

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.14.0/doc/rules/php_unit/php_unit_data_provider_static.rst.