### PR TITLE
[FEATURE] Add `CreditDebitIdentifier` to entry transaction detail

### DIFF
--- a/src/DTO/Entry.php
+++ b/src/DTO/Entry.php
@@ -40,6 +40,8 @@ class Entry
 
     private ?string $status = null;
 
+    private ?string $creditDebitIndicator = null;
+
     public function __construct(Record $record, int $index, Money $amount)
     {
         $this->record = $record;
@@ -185,5 +187,15 @@ class Entry
     public function setStatus(?string $status): void
     {
         $this->status = $status;
+    }
+
+    public function getCreditDebitIndicator(): ?string
+    {
+        return $this->creditDebitIndicator;
+    }
+
+    public function setCreditDebitIndicator(?string $creditDebitIndicator): void
+    {
+        $this->creditDebitIndicator = $creditDebitIndicator;
     }
 }

--- a/src/DTO/EntryTransactionDetail.php
+++ b/src/DTO/EntryTransactionDetail.php
@@ -36,6 +36,8 @@ class EntryTransactionDetail
 
     private ?Money $amount = null;
 
+    private ?string $creditDebitIndicator = null;
+
     public function setReference(?Reference $reference): void
     {
         $this->reference = $reference;
@@ -168,5 +170,15 @@ class EntryTransactionDetail
     public function setAmount(?Money $amount): void
     {
         $this->amount = $amount;
+    }
+
+    public function getCreditDebitIndicator(): ?string
+    {
+        return $this->creditDebitIndicator;
+    }
+
+    public function setCreditDebitIndicator(?string $creditDebitIndicator): void
+    {
+        $this->creditDebitIndicator = $creditDebitIndicator;
     }
 }

--- a/src/Decoder/Entry.php
+++ b/src/Decoder/Entry.php
@@ -23,6 +23,7 @@ class Entry
         if ($xmlDetails !== null) {
             foreach ($xmlDetails as $xmlDetail) {
                 $detail = new DTO\EntryTransactionDetail();
+                $this->entryTransactionDetailDecoder->addCreditDebitIdentifier($detail, $xmlEntry->CdtDbtInd);
                 $this->entryTransactionDetailDecoder->addReference($detail, $xmlDetail);
                 $this->entryTransactionDetailDecoder->addRelatedParties($detail, $xmlDetail);
                 $this->entryTransactionDetailDecoder->addRelatedAgents($detail, $xmlDetail);

--- a/src/Decoder/EntryTransactionDetail.php
+++ b/src/Decoder/EntryTransactionDetail.php
@@ -26,6 +26,15 @@ abstract class EntryTransactionDetail
         $this->moneyFactory = new MoneyFactory();
     }
 
+    public function addCreditDebitIdentifier(DTO\EntryTransactionDetail $detail, SimpleXMLElement $CdtDbtInd): void
+    {
+        $creditDebitIdentifier = (string) $CdtDbtInd;
+        $creditDebitIdentifier = in_array($creditDebitIdentifier, ['CRDT', 'DBIT'], true)
+            ? $creditDebitIdentifier
+            : null;
+        $detail->setCreditDebitIndicator($creditDebitIdentifier);
+    }
+
     public function addReference(DTO\EntryTransactionDetail $detail, SimpleXMLElement $xmlDetail): void
     {
         if (false === isset($xmlDetail->Refs)) {

--- a/src/Decoder/Record.php
+++ b/src/Decoder/Record.php
@@ -121,6 +121,10 @@ class Record
                 $entry->setBatchPaymentId((string) $xmlEntry->NtryDtls->TxDtls->Refs->PmtInfId);
             }
 
+            if (isset($xmlEntry->CdtDbtInd) && in_array((string) $xmlEntry->CdtDbtInd, ['CRDT', 'DBIT'], true)) {
+                $entry->setCreditDebitIndicator((string) $xmlEntry->CdtDbtInd);
+            }
+
             $entry->setStatus($this->readStatus($xmlEntry));
 
             if (isset($xmlEntry->BkTxCd)) {

--- a/test/data/camt052.v1.json
+++ b/test/data/camt052.v1.json
@@ -32,6 +32,7 @@
                 "0": "2007-10-18T09:15:00+00:00"
             },
             "getCharges": null,
+            "getCreditDebitIndicator": "DBIT",
             "getIndex": 0,
             "getRecord": {
                 "__CLASS__": "Genkgo\\Camt\\Camt052\\DTO\\Report",

--- a/test/data/camt052.v2.json
+++ b/test/data/camt052.v2.json
@@ -36,6 +36,7 @@
                 "0": "2007-10-18T09:15:00+00:00"
             },
             "getCharges": null,
+            "getCreditDebitIndicator": "DBIT",
             "getIndex": 0,
             "getRecord": {
                 "__CLASS__": "Genkgo\\Camt\\Camt052\\DTO\\Report",
@@ -86,6 +87,7 @@
                     }
                 },
                 "getCharges": null,
+                "getCreditDebitIndicator": "DBIT",
                 "getReference": null,
                 "getRelatedAgent": {
                     "__CLASS__": "Genkgo\\Camt\\DTO\\RelatedAgent",

--- a/test/data/camt052.v2.other-account.json
+++ b/test/data/camt052.v2.other-account.json
@@ -36,6 +36,7 @@
                 "0": "2007-10-18T09:15:00+00:00"
             },
             "getCharges": null,
+            "getCreditDebitIndicator": "DBIT",
             "getIndex": 0,
             "getRecord": {
                 "__CLASS__": "Genkgo\\Camt\\Camt052\\DTO\\Report",
@@ -86,6 +87,7 @@
                     }
                 },
                 "getCharges": null,
+                "getCreditDebitIndicator": "DBIT",
                 "getReference": null,
                 "getRelatedAgent": {
                     "__CLASS__": "Genkgo\\Camt\\DTO\\RelatedAgent",

--- a/test/data/camt052.v4.json
+++ b/test/data/camt052.v4.json
@@ -36,6 +36,7 @@
                 "0": "2007-10-18T00:00:00+00:00"
             },
             "getCharges": null,
+            "getCreditDebitIndicator": "DBIT",
             "getIndex": 0,
             "getRecord": {
                 "__CLASS__": "Genkgo\\Camt\\Camt052\\DTO\\Report",
@@ -139,6 +140,7 @@
                         }
                     }
                 },
+                "getCreditDebitIndicator": "DBIT",
                 "getReference": {
                     "__CLASS__": "Genkgo\\Camt\\DTO\\Reference",
                     "getAccountOwnerTransactionId": null,

--- a/test/data/camt052.v6.json
+++ b/test/data/camt052.v6.json
@@ -36,6 +36,7 @@
                 "0": "2007-10-18T00:00:00+00:00"
             },
             "getCharges": null,
+            "getCreditDebitIndicator": "DBIT",
             "getIndex": 0,
             "getRecord": {
                 "__CLASS__": "Genkgo\\Camt\\Camt052\\DTO\\Report",
@@ -139,6 +140,7 @@
                         }
                     }
                 },
+                "getCreditDebitIndicator": "DBIT",
                 "getReference": {
                     "__CLASS__": "Genkgo\\Camt\\DTO\\Reference",
                     "getAccountOwnerTransactionId": null,

--- a/test/data/camt052.v8.json
+++ b/test/data/camt052.v8.json
@@ -32,6 +32,7 @@
                 "0": "2007-10-18T09:15:00+00:00"
             },
             "getCharges": null,
+            "getCreditDebitIndicator": "DBIT",
             "getIndex": 0,
             "getRecord": {
                 "__CLASS__": "Genkgo\\Camt\\Camt052\\DTO\\Report",

--- a/test/data/camt053.v2.five.decimals.json
+++ b/test/data/camt053.v2.five.decimals.json
@@ -28,6 +28,7 @@
                 "0": "2014-12-31T00:00:00+00:00"
             },
             "getCharges": null,
+            "getCreditDebitIndicator": "CRDT",
             "getIndex": 0,
             "getRecord": {
                 "__CLASS__": "Genkgo\\Camt\\Camt053\\DTO\\Statement",
@@ -107,6 +108,7 @@
                     }
                 },
                 "getCharges": null,
+                "getCreditDebitIndicator": "CRDT",
                 "getReference": {
                     "__CLASS__": "Genkgo\\Camt\\DTO\\Reference",
                     "getAccountOwnerTransactionId": null,

--- a/test/data/camt053.v2.minimal.json
+++ b/test/data/camt053.v2.minimal.json
@@ -28,6 +28,7 @@
                 "0": "2014-12-31T00:00:00+00:00"
             },
             "getCharges": null,
+            "getCreditDebitIndicator": "CRDT",
             "getIndex": 0,
             "getRecord": {
                 "__CLASS__": "Genkgo\\Camt\\Camt053\\DTO\\Statement",
@@ -145,6 +146,7 @@
                     }
                 },
                 "getCharges": null,
+                "getCreditDebitIndicator": "CRDT",
                 "getReference": {
                     "__CLASS__": "Genkgo\\Camt\\DTO\\Reference",
                     "getAccountOwnerTransactionId": null,

--- a/test/data/camt053.v2.minimal.ultimate.json
+++ b/test/data/camt053.v2.minimal.ultimate.json
@@ -28,6 +28,7 @@
                 "0": "2014-12-31T00:00:00+00:00"
             },
             "getCharges": null,
+            "getCreditDebitIndicator": "CRDT",
             "getIndex": 0,
             "getRecord": {
                 "__CLASS__": "Genkgo\\Camt\\Camt053\\DTO\\Statement",
@@ -145,6 +146,7 @@
                     }
                 },
                 "getCharges": null,
+                "getCreditDebitIndicator": "CRDT",
                 "getReference": {
                     "__CLASS__": "Genkgo\\Camt\\DTO\\Reference",
                     "getAccountOwnerTransactionId": null,

--- a/test/data/camt053.v2.multi.statement.json
+++ b/test/data/camt053.v2.multi.statement.json
@@ -28,6 +28,7 @@
                 "0": "2014-12-31T00:00:00+00:00"
             },
             "getCharges": null,
+            "getCreditDebitIndicator": "DBIT",
             "getIndex": 0,
             "getRecord": {
                 "__CLASS__": "Genkgo\\Camt\\Camt053\\DTO\\Statement",
@@ -107,6 +108,7 @@
                     }
                 },
                 "getCharges": null,
+                "getCreditDebitIndicator": "DBIT",
                 "getReference": {
                     "__CLASS__": "Genkgo\\Camt\\DTO\\Reference",
                     "getAccountOwnerTransactionId": null,

--- a/test/data/camt053.v3.json
+++ b/test/data/camt053.v3.json
@@ -36,6 +36,7 @@
                 "0": "2014-12-31T00:00:00+00:00"
             },
             "getCharges": null,
+            "getCreditDebitIndicator": "CRDT",
             "getIndex": 0,
             "getRecord": {
                 "__CLASS__": "Genkgo\\Camt\\Camt053\\DTO\\Statement",
@@ -154,6 +155,7 @@
                     "getProprietary": null
                 },
                 "getCharges": null,
+                "getCreditDebitIndicator": "CRDT",
                 "getReference": {
                     "__CLASS__": "Genkgo\\Camt\\DTO\\Reference",
                     "getAccountOwnerTransactionId": null,

--- a/test/data/camt053.v4.json
+++ b/test/data/camt053.v4.json
@@ -32,6 +32,7 @@
                 "0": "2014-12-31T00:00:00+00:00"
             },
             "getCharges": null,
+            "getCreditDebitIndicator": "CRDT",
             "getIndex": 0,
             "getRecord": {
                 "__CLASS__": "Genkgo\\Camt\\Camt053\\DTO\\Statement",
@@ -153,6 +154,7 @@
                     "getProprietary": null
                 },
                 "getCharges": null,
+                "getCreditDebitIndicator": "CRDT",
                 "getReference": {
                     "__CLASS__": "Genkgo\\Camt\\DTO\\Reference",
                     "getAccountOwnerTransactionId": null,

--- a/test/data/camt053.v8.json
+++ b/test/data/camt053.v8.json
@@ -32,6 +32,7 @@
                 "0": "2014-12-31T12:15:00+00:00"
             },
             "getCharges": null,
+            "getCreditDebitIndicator": "CRDT",
             "getIndex": 0,
             "getRecord": {
                 "__CLASS__": "Genkgo\\Camt\\Camt053\\DTO\\Statement",
@@ -153,6 +154,7 @@
                     "getProprietary": null
                 },
                 "getCharges": null,
+                "getCreditDebitIndicator": "CRDT",
                 "getReference": {
                     "__CLASS__": "Genkgo\\Camt\\DTO\\Reference",
                     "getAccountOwnerTransactionId": null,

--- a/test/data/camt054.v2.json
+++ b/test/data/camt054.v2.json
@@ -32,6 +32,7 @@
                 "0": "2007-10-18T12:15:00+00:00"
             },
             "getCharges": null,
+            "getCreditDebitIndicator": "DBIT",
             "getIndex": 0,
             "getRecord": {
                 "__CLASS__": "Genkgo\\Camt\\Camt054\\DTO\\Notification",
@@ -77,6 +78,7 @@
                     "getProprietary": null
                 },
                 "getCharges": null,
+                "getCreditDebitIndicator": "DBIT",
                 "getReference": {
                     "__CLASS__": "Genkgo\\Camt\\DTO\\Reference",
                     "getAccountOwnerTransactionId": null,
@@ -150,6 +152,7 @@
                         "getProprietary": null
                     },
                     "getCharges": null,
+                    "getCreditDebitIndicator": "DBIT",
                     "getReference": {
                         "__CLASS__": "Genkgo\\Camt\\DTO\\Reference",
                         "getAccountOwnerTransactionId": null,
@@ -216,6 +219,7 @@
                         "getProprietary": null
                     },
                     "getCharges": null,
+                    "getCreditDebitIndicator": "DBIT",
                     "getReference": {
                         "__CLASS__": "Genkgo\\Camt\\DTO\\Reference",
                         "getAccountOwnerTransactionId": null,

--- a/test/data/camt054.v4.json
+++ b/test/data/camt054.v4.json
@@ -36,6 +36,7 @@
                 "0": "2007-10-18T00:00:00+00:00"
             },
             "getCharges": null,
+            "getCreditDebitIndicator": "DBIT",
             "getIndex": 0,
             "getRecord": {
                 "__CLASS__": "Genkgo\\Camt\\Camt054\\DTO\\Notification",
@@ -112,6 +113,7 @@
                     }
                 },
                 "getCharges": null,
+                "getCreditDebitIndicator": "DBIT",
                 "getReference": {
                     "__CLASS__": "Genkgo\\Camt\\DTO\\Reference",
                     "getAccountOwnerTransactionId": null,
@@ -262,6 +264,7 @@
                         }
                     },
                     "getCharges": null,
+                    "getCreditDebitIndicator": "DBIT",
                     "getReference": {
                         "__CLASS__": "Genkgo\\Camt\\DTO\\Reference",
                         "getAccountOwnerTransactionId": null,
@@ -405,6 +408,7 @@
                         }
                     },
                     "getCharges": null,
+                    "getCreditDebitIndicator": "DBIT",
                     "getReference": {
                         "__CLASS__": "Genkgo\\Camt\\DTO\\Reference",
                         "getAccountOwnerTransactionId": null,

--- a/test/data/camt054.v8-with-UETR.json
+++ b/test/data/camt054.v8-with-UETR.json
@@ -21,6 +21,7 @@
             "getBatchPaymentId": null,
             "getBookingDate": null,
             "getCharges": null,
+            "getCreditDebitIndicator": "DBIT",
             "getIndex": 0,
             "getRecord": {
                 "__CLASS__": "Genkgo\\Camt\\Camt054\\DTO\\Notification",
@@ -62,6 +63,7 @@
                     "getProprietary": null
                 },
                 "getCharges": null,
+                "getCreditDebitIndicator": "DBIT",
                 "getReference": {
                     "__CLASS__": "Genkgo\\Camt\\DTO\\Reference",
                     "getAccountOwnerTransactionId": null,

--- a/test/data/camt054.v8-with-financial-institution.json
+++ b/test/data/camt054.v8-with-financial-institution.json
@@ -21,6 +21,7 @@
             "getBatchPaymentId": null,
             "getBookingDate": null,
             "getCharges": null,
+            "getCreditDebitIndicator": "DBIT",
             "getIndex": 0,
             "getRecord": {
                 "__CLASS__": "Genkgo\\Camt\\Camt054\\DTO\\Notification",
@@ -62,6 +63,7 @@
                     "getProprietary": null
                 },
                 "getCharges": null,
+                "getCreditDebitIndicator": "DBIT",
                 "getReference": null,
                 "getRelatedAgent": null,
                 "getRelatedAgents": [],

--- a/test/data/camt054.v8.json
+++ b/test/data/camt054.v8.json
@@ -36,6 +36,7 @@
                 "0": "2007-10-18T00:00:00+00:00"
             },
             "getCharges": null,
+            "getCreditDebitIndicator": "DBIT",
             "getIndex": 0,
             "getRecord": {
                 "__CLASS__": "Genkgo\\Camt\\Camt054\\DTO\\Notification",
@@ -112,6 +113,7 @@
                     }
                 },
                 "getCharges": null,
+                "getCreditDebitIndicator": "DBIT",
                 "getReference": {
                     "__CLASS__": "Genkgo\\Camt\\DTO\\Reference",
                     "getAccountOwnerTransactionId": null,
@@ -262,6 +264,7 @@
                         }
                     },
                     "getCharges": null,
+                    "getCreditDebitIndicator": "DBIT",
                     "getReference": {
                         "__CLASS__": "Genkgo\\Camt\\DTO\\Reference",
                         "getAccountOwnerTransactionId": null,
@@ -405,6 +408,7 @@
                         }
                     },
                     "getCharges": null,
+                    "getCreditDebitIndicator": "DBIT",
                     "getReference": {
                         "__CLASS__": "Genkgo\\Camt\\DTO\\Reference",
                         "getAccountOwnerTransactionId": null,


### PR DESCRIPTION
The credit-debit-identifier (CrdDbtInd) have been used for
several details, e.g. amount, to proper represent values.
The information itself is not added.

As it could not be reliable retrieved from subvalues what
the original state was, this change now adds that detail
directly to the transaction details and the entry itself.

Test fixture files are updated to contain the added fields.

Resolves: #146
Related: #116
