### PR TITLE
fix(#83): RelatedAgents' BIC may be in BICFI instead of BIC node

### DIFF
--- a/src/Camt054/Decoder/EntryTransactionDetail.php
+++ b/src/Camt054/Decoder/EntryTransactionDetail.php
@@ -63,8 +63,9 @@ class EntryTransactionDetail extends BaseDecoder
 
         return null;
     }
+
     /**
-     * Get Agent BIC from either FinInstnId.BIC or .BICFI, dependeing on protocol version
+     * Get Agent BIC from either FinInstnId.BIC or .BICFI, depending on the protocol version.
      */
     protected function getAgentBic(SimpleXMLElement $xmlAgent): ?SimpleXMLElement
     {

--- a/src/Camt054/Decoder/EntryTransactionDetail.php
+++ b/src/Camt054/Decoder/EntryTransactionDetail.php
@@ -63,4 +63,11 @@ class EntryTransactionDetail extends BaseDecoder
 
         return null;
     }
+    /**
+     * Get Agent BIC from either FinInstnId.BIC or .BICFI, dependeing on protocol version
+     */
+    protected function getAgentBic(SimpleXMLElement $xmlAgent): ?SimpleXMLElement
+    {
+        return $xmlAgent->FinInstnId->BICFI;
+    }
 }

--- a/src/Decoder/EntryTransactionDetail.php
+++ b/src/Decoder/EntryTransactionDetail.php
@@ -133,13 +133,15 @@ abstract class EntryTransactionDetail
 
         foreach ($xmlDetail->RltdAgts as $xmlRelatedAgent) {
             if (isset($xmlRelatedAgent->CdtrAgt)) {
-                $agent = new DTO\CreditorAgent((string) $xmlRelatedAgent->CdtrAgt->FinInstnId->Nm, (string) $xmlRelatedAgent->CdtrAgt->FinInstnId->BIC);
+                $bic = $this->getAgentBic($xmlRelatedAgent->CdtrAgt);
+                $agent = new DTO\CreditorAgent((string) $xmlRelatedAgent->CdtrAgt->FinInstnId->Nm, (string) $bic);
                 $relatedAgent = new DTO\RelatedAgent($agent);
                 $detail->addRelatedAgent($relatedAgent);
             }
 
             if (isset($xmlRelatedAgent->DbtrAgt)) {
-                $agent = new DTO\DebtorAgent((string) $xmlRelatedAgent->DbtrAgt->FinInstnId->Nm, (string) $xmlRelatedAgent->DbtrAgt->FinInstnId->BIC);
+                $bic = $this->getAgentBic($xmlRelatedAgent->DbtrAgt);
+                $agent = new DTO\DebtorAgent((string) $xmlRelatedAgent->DbtrAgt->FinInstnId->Nm, (string) $bic);
                 $relatedAgent = new DTO\RelatedAgent($agent);
                 $detail->addRelatedAgent($relatedAgent);
             }
@@ -354,4 +356,12 @@ abstract class EntryTransactionDetail
     }
 
     abstract public function getRelatedPartyAccount(?SimpleXMLElement $xmlRelatedPartyTypeAccount): ?DTO\Account;
+
+    /**
+     * Get Agent BIC from either FinInstnId.BIC or .BICFI, dependeing on protocol version
+     */
+    protected function getAgentBic(SimpleXMLElement $xmlAgent): ?SimpleXMLElement
+    {
+        return $xmlAgent->FinInstnId->BIC;
+    }
 }

--- a/src/Decoder/EntryTransactionDetail.php
+++ b/src/Decoder/EntryTransactionDetail.php
@@ -358,7 +358,7 @@ abstract class EntryTransactionDetail
     abstract public function getRelatedPartyAccount(?SimpleXMLElement $xmlRelatedPartyTypeAccount): ?DTO\Account;
 
     /**
-     * Get Agent BIC from either FinInstnId.BIC or .BICFI, dependeing on protocol version
+     * Get Agent BIC from either FinInstnId.BIC or .BICFI, depending on the protocol version.
      */
     protected function getAgentBic(SimpleXMLElement $xmlAgent): ?SimpleXMLElement
     {

--- a/test/Unit/RegressionTest.php
+++ b/test/Unit/RegressionTest.php
@@ -30,7 +30,7 @@ class RegressionTest extends TestCase
     public function testRegression(string $file): void
     {
         $reader = new Reader(Config::getDefault());
-        $message = $reader->readFile($file);
+        $message = $reader->readFile(__DIR__.'/../../'.$file);
 
         $dumper = new Dumper();
         $actual = $dumper->dump($message);

--- a/test/Unit/RegressionTest.php
+++ b/test/Unit/RegressionTest.php
@@ -30,7 +30,7 @@ class RegressionTest extends TestCase
     public function testRegression(string $file): void
     {
         $reader = new Reader(Config::getDefault());
-        $message = $reader->readFile(__DIR__.'/../../'.$file);
+        $message = $reader->readFile($file);
 
         $dumper = new Dumper();
         $actual = $dumper->dump($message);

--- a/test/data/camt054.v4.json
+++ b/test/data/camt054.v4.json
@@ -146,7 +146,7 @@
                         "__CLASS__": "Genkgo\\Camt\\DTO\\RelatedAgent",
                         "getRelatedAgentType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\DebtorAgent",
-                            "getBIC": "",
+                            "getBIC": "BANKCHZHXXX",
                             "getName": ""
                         }
                     }
@@ -287,7 +287,7 @@
                         "__CLASS__": "Genkgo\\Camt\\DTO\\RelatedAgent",
                         "getRelatedAgentType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\CreditorAgent",
-                            "getBIC": "",
+                            "getBIC": "BANKCHBE",
                             "getName": ""
                         }
                     },
@@ -297,7 +297,7 @@
                             "__CLASS__": "Genkgo\\Camt\\DTO\\RelatedAgent",
                             "getRelatedAgentType": {
                                 "__CLASS__": "Genkgo\\Camt\\DTO\\DebtorAgent",
-                                "getBIC": "",
+                                "getBIC": "BANKCHZHXXX",
                                 "getName": ""
                             }
                         }
@@ -431,7 +431,7 @@
                         "__CLASS__": "Genkgo\\Camt\\DTO\\RelatedAgent",
                         "getRelatedAgentType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\CreditorAgent",
-                            "getBIC": "",
+                            "getBIC": "BANKCHBE",
                             "getName": ""
                         }
                     },
@@ -441,7 +441,7 @@
                             "__CLASS__": "Genkgo\\Camt\\DTO\\RelatedAgent",
                             "getRelatedAgentType": {
                                 "__CLASS__": "Genkgo\\Camt\\DTO\\DebtorAgent",
-                                "getBIC": "",
+                                "getBIC": "BANKCHZHXXX",
                                 "getName": ""
                             }
                         }

--- a/test/data/camt054.v8.json
+++ b/test/data/camt054.v8.json
@@ -146,7 +146,7 @@
                         "__CLASS__": "Genkgo\\Camt\\DTO\\RelatedAgent",
                         "getRelatedAgentType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\DebtorAgent",
-                            "getBIC": "",
+                            "getBIC": "BANKCHZHXXX",
                             "getName": ""
                         }
                     }
@@ -287,7 +287,7 @@
                         "__CLASS__": "Genkgo\\Camt\\DTO\\RelatedAgent",
                         "getRelatedAgentType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\CreditorAgent",
-                            "getBIC": "",
+                            "getBIC": "BANKCHBE",
                             "getName": ""
                         }
                     },
@@ -297,7 +297,7 @@
                             "__CLASS__": "Genkgo\\Camt\\DTO\\RelatedAgent",
                             "getRelatedAgentType": {
                                 "__CLASS__": "Genkgo\\Camt\\DTO\\DebtorAgent",
-                                "getBIC": "",
+                                "getBIC": "BANKCHZHXXX",
                                 "getName": ""
                             }
                         }
@@ -431,7 +431,7 @@
                         "__CLASS__": "Genkgo\\Camt\\DTO\\RelatedAgent",
                         "getRelatedAgentType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\CreditorAgent",
-                            "getBIC": "",
+                            "getBIC": "BANKCHBE",
                             "getName": ""
                         }
                     },
@@ -441,7 +441,7 @@
                             "__CLASS__": "Genkgo\\Camt\\DTO\\RelatedAgent",
                             "getRelatedAgentType": {
                                 "__CLASS__": "Genkgo\\Camt\\DTO\\DebtorAgent",
-                                "getBIC": "",
+                                "getBIC": "BANKCHZHXXX",
                                 "getName": ""
                             }
                         }


### PR DESCRIPTION
This fixes issue #83 for us, where at least in the camt.054.001.08 documents we receive the related agents' BIC are in BICFI nodes.
Test cases are also modified of course.