### PR TITLE
Add PHP 8.4 to build matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,7 @@ jobs:
           - '8.1'
           - '8.2'
           - '8.3'
+          - '8.4'
 
     name: PHP ${{ matrix.php-version }}
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "ext-libxml": "*",
         "ext-simplexml": "*",
         "moneyphp/money": "^4.6",
-        "jschaedl/iban-validation": "^2.0"
+        "jschaedl/iban-validation": "^2.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "ext-dom": "*",
         "ext-libxml": "*",
         "ext-simplexml": "*",
-        "moneyphp/money": "^4.0",
+        "moneyphp/money": "^4.6",
         "jschaedl/iban-validation": "^2.0"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "df1276f8adfed2e227d247c73fd0af05",
+    "content-hash": "b28a1a560a7fd1f5f966a76fd045269f",
     "packages": [
         {
             "name": "jschaedl/iban-validation",
@@ -67,41 +67,41 @@
         },
         {
             "name": "moneyphp/money",
-            "version": "v4.3.0",
+            "version": "v4.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/moneyphp/money.git",
-                "reference": "50ddfd15b2be01d4bed3bcb0c975a6af5f78a183"
+                "reference": "ddf6a86b574808f8844777ed4e8c4f92a10dac9b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/moneyphp/money/zipball/50ddfd15b2be01d4bed3bcb0c975a6af5f78a183",
-                "reference": "50ddfd15b2be01d4bed3bcb0c975a6af5f78a183",
+                "url": "https://api.github.com/repos/moneyphp/money/zipball/ddf6a86b574808f8844777ed4e8c4f92a10dac9b",
+                "reference": "ddf6a86b574808f8844777ed4e8c4f92a10dac9b",
                 "shasum": ""
             },
             "require": {
                 "ext-bcmath": "*",
                 "ext-filter": "*",
                 "ext-json": "*",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0"
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
             },
             "require-dev": {
                 "cache/taggable-cache": "^1.1.0",
-                "doctrine/coding-standard": "^9.0",
-                "doctrine/instantiator": "^1.4.0",
+                "doctrine/coding-standard": "^12.0",
+                "doctrine/instantiator": "^1.5.0 || ^2.0",
                 "ext-gmp": "*",
                 "ext-intl": "*",
-                "florianv/exchanger": "^2.6.3",
+                "florianv/exchanger": "^2.8.1",
                 "florianv/swap": "^4.3.0",
-                "moneyphp/crypto-currencies": "^1.0.0",
-                "moneyphp/iso-currencies": "^3.2.1",
-                "php-http/message": "^1.11.0",
-                "php-http/mock-client": "^1.4.1",
+                "moneyphp/crypto-currencies": "^1.1.0",
+                "moneyphp/iso-currencies": "^3.4",
+                "php-http/message": "^1.16.0",
+                "php-http/mock-client": "^1.6.0",
                 "phpbench/phpbench": "^1.2.5",
-                "phpunit/phpunit": "^9.5.4",
+                "phpunit/phpunit": "^10.5.9",
                 "psalm/plugin-phpunit": "^0.18.4",
-                "psr/cache": "^1.0.1",
-                "vimeo/psalm": "~5.15.0"
+                "psr/cache": "^1.0.1 || ^2.0 || ^3.0",
+                "vimeo/psalm": "~5.20.0"
             },
             "suggest": {
                 "ext-gmp": "Calculate without integer limits",
@@ -149,9 +149,9 @@
             ],
             "support": {
                 "issues": "https://github.com/moneyphp/money/issues",
-                "source": "https://github.com/moneyphp/money/tree/v4.3.0"
+                "source": "https://github.com/moneyphp/money/tree/v4.6.0"
             },
-            "time": "2023-11-22T09:46:30+00:00"
+            "time": "2024-11-22T10:59:03+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -3599,6 +3599,6 @@
         "ext-libxml": "*",
         "ext-simplexml": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,25 +4,25 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b28a1a560a7fd1f5f966a76fd045269f",
+    "content-hash": "a67d4556ff668ed6e7c1193eed221d0e",
     "packages": [
         {
             "name": "jschaedl/iban-validation",
-            "version": "v2.3.0",
+            "version": "v2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jschaedl/iban-validation.git",
-                "reference": "27ef93772489833b0ee447fb12b8bcc0ba47c09e"
+                "reference": "7e8b9d428a756d1351c4551a32ef040eba847076"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jschaedl/iban-validation/zipball/27ef93772489833b0ee447fb12b8bcc0ba47c09e",
-                "reference": "27ef93772489833b0ee447fb12b8bcc0ba47c09e",
+                "url": "https://api.github.com/repos/jschaedl/iban-validation/zipball/7e8b9d428a756d1351c4551a32ef040eba847076",
+                "reference": "7e8b9d428a756d1351c4551a32ef040eba847076",
                 "shasum": ""
             },
             "require": {
                 "ext-ctype": "*",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
+                "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
                 "symfony/options-resolver": "^5.4|^6|^7"
             },
             "require-dev": {
@@ -61,9 +61,9 @@
             ],
             "support": {
                 "issues": "https://github.com/jschaedl/iban-validation/issues",
-                "source": "https://github.com/jschaedl/iban-validation/tree/v2.3.0"
+                "source": "https://github.com/jschaedl/iban-validation/tree/v2.5.0"
             },
-            "time": "2023-11-30T17:08:05+00:00"
+            "time": "2024-11-24T13:07:33+00:00"
         },
         {
             "name": "moneyphp/money",


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/main.yml` file. The change adds support for PHP version 8.4 to the CI workflow.

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R12): Added PHP version 8.4 to the matrix of versions to test in the CI workflow.

It might very well be that when the pipeline is executed some deprecations might pop up. If any show up I am willing to spend some additional time in getting them resolved.