### PR TITLE
Add support for named iban accounts

### DIFF
--- a/src/Camt052/Decoder/EntryTransactionDetail.php
+++ b/src/Camt052/Decoder/EntryTransactionDetail.php
@@ -25,7 +25,9 @@ class EntryTransactionDetail extends BaseDecoder
         }
 
         if (isset($xmlRelatedPartyTypeAccount->Id->IBAN)) {
-            return new DTO\IbanAccount(new Iban((string) $xmlRelatedPartyTypeAccount->Id->IBAN));
+            $name = isset($xmlRelatedPartyTypeAccount->Nm) ? (string) $xmlRelatedPartyTypeAccount->Nm : null;
+
+            return new DTO\IbanAccount(new Iban((string) $xmlRelatedPartyTypeAccount->Id->IBAN), $name);
         }
 
         if (isset($xmlRelatedPartyTypeAccount->Id->BBAN)) {

--- a/src/Camt052/Decoder/Message.php
+++ b/src/Camt052/Decoder/Message.php
@@ -50,7 +50,9 @@ abstract class Message extends BaseMessageDecoder
     protected function getAccount(SimpleXMLElement $xmlRecord): Account
     {
         if (isset($xmlRecord->Acct->Id->IBAN)) {
-            return new DTO\IbanAccount(new Iban((string) $xmlRecord->Acct->Id->IBAN));
+            $name = isset($xmlRecord->Acct->Nm) ? (string) $xmlRecord->Acct->Nm : null;
+
+            return new DTO\IbanAccount(new Iban((string) $xmlRecord->Acct->Id->IBAN), $name);
         }
 
         if (isset($xmlRecord->Acct->Id->BBAN)) {

--- a/src/Camt053/Decoder/EntryTransactionDetail.php
+++ b/src/Camt053/Decoder/EntryTransactionDetail.php
@@ -25,7 +25,9 @@ class EntryTransactionDetail extends BaseDecoder
         }
 
         if (isset($xmlRelatedPartyTypeAccount->Id->IBAN) && $ibanCode = (string) $xmlRelatedPartyTypeAccount->Id->IBAN) {
-            return new DTO\IbanAccount(new Iban($ibanCode));
+            $name = isset($xmlRelatedPartyTypeAccount->Nm) ? (string) $xmlRelatedPartyTypeAccount->Nm : null;
+
+            return new DTO\IbanAccount(new Iban($ibanCode), $name);
         }
 
         if (false === isset($xmlRelatedPartyTypeAccount->Id->Othr)) {

--- a/src/Camt053/Decoder/Message.php
+++ b/src/Camt053/Decoder/Message.php
@@ -56,7 +56,9 @@ class Message extends BaseMessageDecoder
     protected function getAccount(SimpleXMLElement $xmlRecord): DTO\Account
     {
         if (isset($xmlRecord->Acct->Id->IBAN)) {
-            return new DTO\IbanAccount(new Iban((string) $xmlRecord->Acct->Id->IBAN));
+            $name = isset($xmlRecord->Acct->Nm) ? (string) $xmlRecord->Acct->Nm : null;
+
+            return new DTO\IbanAccount(new Iban((string) $xmlRecord->Acct->Id->IBAN), $name);
         }
 
         $xmlOtherIdentification = $xmlRecord->Acct->Id->Othr;

--- a/src/Camt054/Decoder/EntryTransactionDetail.php
+++ b/src/Camt054/Decoder/EntryTransactionDetail.php
@@ -25,7 +25,9 @@ class EntryTransactionDetail extends BaseDecoder
         }
 
         if (isset($xmlRelatedPartyTypeAccount->Id->IBAN)) {
-            return new DTO\IbanAccount(new Iban((string) $xmlRelatedPartyTypeAccount->Id->IBAN));
+            $name = isset($xmlRelatedPartyTypeAccount->Nm) ? (string) $xmlRelatedPartyTypeAccount->Nm : null;
+
+            return new DTO\IbanAccount(new Iban((string) $xmlRelatedPartyTypeAccount->Id->IBAN), $name);
         }
 
         if (isset($xmlRelatedPartyTypeAccount->Id->BBAN)) {

--- a/src/Camt054/Decoder/Message.php
+++ b/src/Camt054/Decoder/Message.php
@@ -57,7 +57,9 @@ class Message extends BaseMessageDecoder
     protected function getAccount(SimpleXMLElement $xmlRecord): Account
     {
         if (isset($xmlRecord->Acct->Id->IBAN)) {
-            return new DTO\IbanAccount(new Iban((string) $xmlRecord->Acct->Id->IBAN));
+            $name = isset($xmlRecord->Acct->Nm) ? (string) $xmlRecord->Acct->Nm : null;
+
+            return new DTO\IbanAccount(new Iban((string) $xmlRecord->Acct->Id->IBAN), $name);
         }
 
         if (isset($xmlRecord->Acct->Id->BBAN)) {

--- a/src/DTO/IbanAccount.php
+++ b/src/DTO/IbanAccount.php
@@ -8,16 +8,20 @@ use Genkgo\Camt\Iban;
 
 class IbanAccount extends Account
 {
-    private Iban $iban;
-
-    public function __construct(Iban $iban)
-    {
-        $this->iban = $iban;
+    public function __construct(
+        private readonly Iban $iban,
+        private readonly ?string $name,
+    ) {
     }
 
     public function getIban(): Iban
     {
         return $this->iban;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
     }
 
     /**

--- a/test/data/camt052.v2.json
+++ b/test/data/camt052.v2.json
@@ -118,7 +118,8 @@
                                 "__CLASS__": "Genkgo\\Camt\\Iban",
                                 "getIban": "NL56AGDH9619008421"
                             },
-                            "getIdentification": "NL56AGDH9619008421"
+                            "getIdentification": "NL56AGDH9619008421",
+                            "getName": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",
@@ -145,7 +146,8 @@
                                 "__CLASS__": "Genkgo\\Camt\\Iban",
                                 "getIban": "NL56AGDH9619008421"
                             },
-                            "getIdentification": "NL56AGDH9619008421"
+                            "getIdentification": "NL56AGDH9619008421",
+                            "getName": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",

--- a/test/data/camt052.v2.with-account-name.json
+++ b/test/data/camt052.v2.with-account-name.json
@@ -24,7 +24,7 @@
             "getCreditDebitIndicator": "DBIT",
             "getIndex": 0,
             "getRecord": {
-                "__CLASS__": "Genkgo\\Camt\\Camt054\\DTO\\Notification",
+                "__CLASS__": "Genkgo\\Camt\\Camt052\\DTO\\Report",
                 "getAccount": {
                     "__CLASS__": "Genkgo\\Camt\\DTO\\IbanAccount",
                     "getIban": {
@@ -32,9 +32,10 @@
                         "getIban": "CH2801234000123456789"
                     },
                     "getIdentification": "CH2801234000123456789",
-                    "getName": null
+                    "getName": "Account Owner Name"
                 },
                 "getAdditionalInformation": null,
+                "getBalances": [],
                 "getCopyDuplicateIndicator": null,
                 "getCreatedOn": {
                     "__CLASS__": "DateTimeImmutable",
@@ -65,29 +66,47 @@
                 },
                 "getCharges": null,
                 "getCreditDebitIndicator": "DBIT",
-                "getReference": {
-                    "__CLASS__": "Genkgo\\Camt\\DTO\\Reference",
-                    "getAccountOwnerTransactionId": null,
-                    "getAccountServicerReference": null,
-                    "getAccountServicerTransactionId": null,
-                    "getChequeNumber": null,
-                    "getClearingSystemReference": null,
-                    "getEndToEndId": null,
-                    "getInstructionId": null,
-                    "getMandateId": null,
-                    "getMarketInfrastructureTransactionId": null,
-                    "getMessageId": null,
-                    "getPaymentInformationId": null,
-                    "getProcessingId": null,
-                    "getProprietaries": [],
-                    "getTransactionId": null,
-                    "getUuidEndToEndReference": "255ae394-9965-4438-ac86-f406feada396"
-                },
+                "getReference": null,
                 "getRelatedAgent": null,
                 "getRelatedAgents": [],
                 "getRelatedDates": null,
-                "getRelatedParties": [],
-                "getRelatedParty": null,
+                "getRelatedParties": [
+                    {
+                        "__CLASS__": "Genkgo\\Camt\\DTO\\RelatedParty",
+                        "getAccount": {
+                            "__CLASS__": "Genkgo\\Camt\\DTO\\IbanAccount",
+                            "getIban": {
+                                "__CLASS__": "Genkgo\\Camt\\Iban",
+                                "getIban": "CH2801234000123456789"
+                            },
+                            "getIdentification": "CH2801234000123456789",
+                            "getName": "Creditor Account Name"
+                        },
+                        "getRelatedPartyType": {
+                            "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",
+                            "getAddress": null,
+                            "getName": "Company Name"
+                        }
+                    },
+                    {
+                        "__CLASS__": "Genkgo\\Camt\\DTO\\RelatedParty",
+                        "getAccount": {
+                            "__CLASS__": "Genkgo\\Camt\\DTO\\IbanAccount",
+                            "getIban": {
+                                "__CLASS__": "Genkgo\\Camt\\Iban",
+                                "getIban": "CH2801234000123456789"
+                            },
+                            "getIdentification": "CH2801234000123456789",
+                            "getName": "Debitor Account Name"
+                        },
+                        "getRelatedPartyType": {
+                            "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",
+                            "getAddress": null,
+                            "getName": "NAME NAME"
+                        }
+                    }
+                ],
+                "getRelatedParty": "__RECURSIVITY__",
                 "getRemittanceInformation": null,
                 "getReturnInformation": null
             },
@@ -98,7 +117,7 @@
         }
     ],
     "getGroupHeader": {
-        "__CLASS__": "Genkgo\\Camt\\Camt054\\DTO\\V04\\GroupHeader",
+        "__CLASS__": "Genkgo\\Camt\\DTO\\GroupHeader",
         "getAdditionalInformation": null,
         "getCreatedOn": {
             "__CLASS__": "DateTimeImmutable",
@@ -106,7 +125,6 @@
         },
         "getMessageId": "AAAASESS-FP-ACCR001",
         "getMessageRecipient": null,
-        "getOriginalBusinessQuery": null,
         "getPagination": null
     },
     "getRecords": [

--- a/test/data/camt052.v2.with-account-name.xml
+++ b/test/data/camt052.v2.with-account-name.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:iso:std:iso:20022:tech:xsd:camt.052.001.02">
+    <BkToCstmrAcctRpt>
+        <GrpHdr>
+            <MsgId>AAAASESS-FP-ACCR001</MsgId>
+            <CreDtTm>2007-10-18T12:30:00+01:00</CreDtTm>
+        </GrpHdr>
+        <Rpt>
+            <Id>AAAASESS-FP-ACCR001</Id>
+            <CreDtTm>2007-10-18T12:30:00+01:00</CreDtTm>
+            <Acct>
+                <Id>
+                    <IBAN>CH2801234000123456789</IBAN>
+                </Id>
+                <Nm>Account Owner Name</Nm>
+            </Acct>
+            <Ntry>
+                <Amt Ccy="SEK">200000</Amt>
+                <CdtDbtInd>DBIT</CdtDbtInd>
+                <Sts>BOOK</Sts>
+                <BkTxCd>
+                </BkTxCd>
+                <NtryDtls>
+                    <TxDtls>
+                        <RltdPties>
+                            <Dbtr>
+                                <Nm>NAME NAME</Nm>
+                            </Dbtr>
+                            <DbtrAcct>
+                                <Id>
+                                    <IBAN>CH2801234000123456789</IBAN>
+                                </Id>
+                                <Nm>Debitor Account Name</Nm>
+                            </DbtrAcct>
+                            <Cdtr>
+                                <Nm>Company Name</Nm>
+                            </Cdtr>
+                            <CdtrAcct>
+                                <Id>
+                                    <IBAN>CH2801234000123456789</IBAN>
+                                </Id>
+                                <Nm>Creditor Account Name</Nm>
+                            </CdtrAcct>
+                        </RltdPties>
+                    </TxDtls>
+                </NtryDtls>
+            </Ntry>
+        </Rpt>
+    </BkToCstmrAcctRpt>
+</Document>

--- a/test/data/camt052.v4.json
+++ b/test/data/camt052.v4.json
@@ -46,7 +46,8 @@
                         "__CLASS__": "Genkgo\\Camt\\Iban",
                         "getIban": "CH2801234000123456789"
                     },
-                    "getIdentification": "CH2801234000123456789"
+                    "getIdentification": "CH2801234000123456789",
+                    "getName": null
                 },
                 "getAdditionalInformation": "Additional Information",
                 "getBalances": [
@@ -205,7 +206,8 @@
                                 "__CLASS__": "Genkgo\\Camt\\Iban",
                                 "getIban": "CH2801234000123456789"
                             },
-                            "getIdentification": "CH2801234000123456789"
+                            "getIdentification": "CH2801234000123456789",
+                            "getName": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",
@@ -221,7 +223,8 @@
                                 "__CLASS__": "Genkgo\\Camt\\Iban",
                                 "getIban": "CH2401234004141414141"
                             },
-                            "getIdentification": "CH2401234004141414141"
+                            "getIdentification": "CH2401234004141414141",
+                            "getName": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",

--- a/test/data/camt052.v6.json
+++ b/test/data/camt052.v6.json
@@ -46,7 +46,8 @@
                         "__CLASS__": "Genkgo\\Camt\\Iban",
                         "getIban": "CH2801234000123456789"
                     },
-                    "getIdentification": "CH2801234000123456789"
+                    "getIdentification": "CH2801234000123456789",
+                    "getName": null
                 },
                 "getAdditionalInformation": "Additional Information",
                 "getBalances": [
@@ -205,7 +206,8 @@
                                 "__CLASS__": "Genkgo\\Camt\\Iban",
                                 "getIban": "CH2801234000123456789"
                             },
-                            "getIdentification": "CH2801234000123456789"
+                            "getIdentification": "CH2801234000123456789",
+                            "getName": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",
@@ -221,7 +223,8 @@
                                 "__CLASS__": "Genkgo\\Camt\\Iban",
                                 "getIban": "CH2401234004141414141"
                             },
-                            "getIdentification": "CH2401234004141414141"
+                            "getIdentification": "CH2401234004141414141",
+                            "getName": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",

--- a/test/data/camt053.v2.all-balance-types.json
+++ b/test/data/camt053.v2.all-balance-types.json
@@ -265,7 +265,8 @@
                                 "__CLASS__": "Genkgo\\Camt\\Iban",
                                 "getIban": "NL56AGDH9619008421"
                             },
-                            "getIdentification": "NL56AGDH9619008421"
+                            "getIdentification": "NL56AGDH9619008421",
+                            "getName": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",

--- a/test/data/camt053.v2.five.decimals.json
+++ b/test/data/camt053.v2.five.decimals.json
@@ -38,7 +38,8 @@
                         "__CLASS__": "Genkgo\\Camt\\Iban",
                         "getIban": "NL26VAYB8060476890"
                     },
-                    "getIdentification": "NL26VAYB8060476890"
+                    "getIdentification": "NL26VAYB8060476890",
+                    "getName": null
                 },
                 "getAdditionalInformation": "Additional Information",
                 "getBalances": [
@@ -139,7 +140,8 @@
                                 "__CLASS__": "Genkgo\\Camt\\Iban",
                                 "getIban": "NL56AGDH9619008421"
                             },
-                            "getIdentification": "NL56AGDH9619008421"
+                            "getIdentification": "NL56AGDH9619008421",
+                            "getName": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",

--- a/test/data/camt053.v2.minimal.json
+++ b/test/data/camt053.v2.minimal.json
@@ -38,7 +38,8 @@
                         "__CLASS__": "Genkgo\\Camt\\Iban",
                         "getIban": "NL26VAYB8060476890"
                     },
-                    "getIdentification": "NL26VAYB8060476890"
+                    "getIdentification": "NL26VAYB8060476890",
+                    "getName": null
                 },
                 "getAdditionalInformation": "Additional Information",
                 "getBalances": [
@@ -183,7 +184,8 @@
                                 "__CLASS__": "Genkgo\\Camt\\Iban",
                                 "getIban": "NL56AGDH9619008421"
                             },
-                            "getIdentification": "NL56AGDH9619008421"
+                            "getIdentification": "NL56AGDH9619008421",
+                            "getName": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",
@@ -210,7 +212,8 @@
                                 "__CLASS__": "Genkgo\\Camt\\Iban",
                                 "getIban": "NL56AGDH9619008421"
                             },
-                            "getIdentification": "NL56AGDH9619008421"
+                            "getIdentification": "NL56AGDH9619008421",
+                            "getName": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",

--- a/test/data/camt053.v2.minimal.ultimate.json
+++ b/test/data/camt053.v2.minimal.ultimate.json
@@ -38,7 +38,8 @@
                         "__CLASS__": "Genkgo\\Camt\\Iban",
                         "getIban": "NL26VAYB8060476890"
                     },
-                    "getIdentification": "NL26VAYB8060476890"
+                    "getIdentification": "NL26VAYB8060476890",
+                    "getName": null
                 },
                 "getAdditionalInformation": "Additional Information",
                 "getBalances": [

--- a/test/data/camt053.v2.multi.statement.json
+++ b/test/data/camt053.v2.multi.statement.json
@@ -38,7 +38,8 @@
                         "__CLASS__": "Genkgo\\Camt\\Iban",
                         "getIban": "NL26VAYB8060476890"
                     },
-                    "getIdentification": "NL26VAYB8060476890"
+                    "getIdentification": "NL26VAYB8060476890",
+                    "getName": null
                 },
                 "getAdditionalInformation": "Additional Information",
                 "getBalances": [
@@ -139,7 +140,8 @@
                                 "__CLASS__": "Genkgo\\Camt\\Iban",
                                 "getIban": "NL56AGDH9619008421"
                             },
-                            "getIdentification": "NL56AGDH9619008421"
+                            "getIdentification": "NL56AGDH9619008421",
+                            "getName": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",

--- a/test/data/camt053.v2.with-account-name.json
+++ b/test/data/camt053.v2.with-account-name.json
@@ -7,24 +7,31 @@
             "getAdditionalInfo": "",
             "getAmount": {
                 "__CLASS__": "Money\\Money",
-                "getAmount": "-20000000",
+                "getAmount": "885",
                 "getCurrency": {
                     "__CLASS__": "Money\\Currency",
-                    "getCode": "SEK"
+                    "getCode": "EUR"
                 }
             },
             "getBankTransactionCode": {
                 "__CLASS__": "Genkgo\\Camt\\DTO\\BankTransactionCode",
                 "getDomain": null,
-                "getProprietary": null
+                "getProprietary": {
+                    "__CLASS__": "Genkgo\\Camt\\DTO\\ProprietaryBankTransactionCode",
+                    "getCode": "544",
+                    "getIssuer": ""
+                }
             },
             "getBatchPaymentId": null,
-            "getBookingDate": null,
+            "getBookingDate": {
+                "__CLASS__": "DateTimeImmutable",
+                "0": "2014-12-31T00:00:00+00:00"
+            },
             "getCharges": null,
-            "getCreditDebitIndicator": "DBIT",
+            "getCreditDebitIndicator": "CRDT",
             "getIndex": 0,
             "getRecord": {
-                "__CLASS__": "Genkgo\\Camt\\Camt054\\DTO\\Notification",
+                "__CLASS__": "Genkgo\\Camt\\Camt053\\DTO\\Statement",
                 "getAccount": {
                     "__CLASS__": "Genkgo\\Camt\\DTO\\IbanAccount",
                     "getIban": {
@@ -32,20 +39,38 @@
                         "getIban": "CH2801234000123456789"
                     },
                     "getIdentification": "CH2801234000123456789",
-                    "getName": null
+                    "getName": "Account Owner Name"
                 },
                 "getAdditionalInformation": null,
+                "getBalances": [
+                    {
+                        "__CLASS__": "Genkgo\\Camt\\DTO\\Balance",
+                        "getAmount": {
+                            "__CLASS__": "Money\\Money",
+                            "getAmount": "-2700",
+                            "getCurrency": {
+                                "__CLASS__": "Money\\Currency",
+                                "getCode": "JPY"
+                            }
+                        },
+                        "getDate": {
+                            "__CLASS__": "DateTimeImmutable",
+                            "0": "2014-12-31T00:00:00+00:00"
+                        },
+                        "getType": "closing_available"
+                    }
+                ],
                 "getCopyDuplicateIndicator": null,
                 "getCreatedOn": {
                     "__CLASS__": "DateTimeImmutable",
-                    "0": "2007-10-18T11:30:00+00:00"
+                    "0": "2015-03-10T18:43:50+00:00"
                 },
                 "getElectronicSequenceNumber": null,
                 "getEntries": [
                     "__RECURSIVITY__"
                 ],
                 "getFromDate": null,
-                "getId": "AAAASESS-FP-ACCR001",
+                "getId": "253EURCH2801234000123456789",
                 "getLegalSequenceNumber": null,
                 "getPagination": null,
                 "getToDate": null
@@ -64,30 +89,31 @@
                     "getProprietary": null
                 },
                 "getCharges": null,
-                "getCreditDebitIndicator": "DBIT",
-                "getReference": {
-                    "__CLASS__": "Genkgo\\Camt\\DTO\\Reference",
-                    "getAccountOwnerTransactionId": null,
-                    "getAccountServicerReference": null,
-                    "getAccountServicerTransactionId": null,
-                    "getChequeNumber": null,
-                    "getClearingSystemReference": null,
-                    "getEndToEndId": null,
-                    "getInstructionId": null,
-                    "getMandateId": null,
-                    "getMarketInfrastructureTransactionId": null,
-                    "getMessageId": null,
-                    "getPaymentInformationId": null,
-                    "getProcessingId": null,
-                    "getProprietaries": [],
-                    "getTransactionId": null,
-                    "getUuidEndToEndReference": "255ae394-9965-4438-ac86-f406feada396"
-                },
+                "getCreditDebitIndicator": "CRDT",
+                "getReference": null,
                 "getRelatedAgent": null,
                 "getRelatedAgents": [],
                 "getRelatedDates": null,
-                "getRelatedParties": [],
-                "getRelatedParty": null,
+                "getRelatedParties": [
+                    {
+                        "__CLASS__": "Genkgo\\Camt\\DTO\\RelatedParty",
+                        "getAccount": {
+                            "__CLASS__": "Genkgo\\Camt\\DTO\\IbanAccount",
+                            "getIban": {
+                                "__CLASS__": "Genkgo\\Camt\\Iban",
+                                "getIban": "CH2801234000123456789"
+                            },
+                            "getIdentification": "CH2801234000123456789",
+                            "getName": "Creditor Account Name"
+                        },
+                        "getRelatedPartyType": {
+                            "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",
+                            "getAddress": null,
+                            "getName": "Company Name"
+                        }
+                    }
+                ],
+                "getRelatedParty": "__RECURSIVITY__",
                 "getRemittanceInformation": null,
                 "getReturnInformation": null
             },
@@ -98,15 +124,14 @@
         }
     ],
     "getGroupHeader": {
-        "__CLASS__": "Genkgo\\Camt\\Camt054\\DTO\\V04\\GroupHeader",
+        "__CLASS__": "Genkgo\\Camt\\DTO\\GroupHeader",
         "getAdditionalInformation": null,
         "getCreatedOn": {
             "__CLASS__": "DateTimeImmutable",
-            "0": "2007-10-18T11:30:00+00:00"
+            "0": "2015-03-10T18:43:50+00:00"
         },
-        "getMessageId": "AAAASESS-FP-ACCR001",
+        "getMessageId": "CAMT053RIB000000000001",
         "getMessageRecipient": null,
-        "getOriginalBusinessQuery": null,
         "getPagination": null
     },
     "getRecords": [

--- a/test/data/camt053.v2.with-account-name.xml
+++ b/test/data/camt053.v2.with-account-name.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:iso:std:iso:20022:tech:xsd:camt.053.001.02">
+    <BkToCstmrStmt>
+        <GrpHdr>
+            <MsgId>CAMT053RIB000000000001</MsgId>
+            <CreDtTm>2015-03-10T18:43:50+00:00</CreDtTm>
+        </GrpHdr>
+        <Stmt>
+            <Id>253EURCH2801234000123456789</Id>
+            <CreDtTm>2015-03-10T18:43:50+00:00</CreDtTm>
+            <Acct>
+                <Id>
+                    <IBAN>CH2801234000123456789</IBAN>
+                </Id>
+                <Nm>Account Owner Name</Nm>
+            </Acct>
+            <Bal>
+                <Tp>
+                    <CdOrPrtry>
+                        <Cd>CLAV</Cd>
+                    </CdOrPrtry>
+                </Tp>
+                <Amt Ccy="JPY">2700</Amt>
+                <CdtDbtInd>DBIT</CdtDbtInd>
+                <Dt>
+                    <Dt>2014-12-31</Dt>
+                </Dt>
+            </Bal>
+            <Ntry>
+                <Amt Ccy="EUR">8.85</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <RvslInd>false</RvslInd>
+                <Sts>BOOK</Sts>
+                <BookgDt>
+                    <Dt>2014-12-31</Dt>
+                </BookgDt>
+                <BkTxCd>
+                    <Prtry>
+                        <Cd>544</Cd>
+                    </Prtry>
+                </BkTxCd>
+                <NtryDtls>
+                    <TxDtls>
+                        <RltdPties>
+                            <Cdtr>
+                                <Nm>Company Name</Nm>
+                            </Cdtr>
+                            <CdtrAcct>
+                                <Id>
+                                    <IBAN>CH2801234000123456789</IBAN>
+                                </Id>
+                                <Nm>Creditor Account Name</Nm>
+                            </CdtrAcct>
+                        </RltdPties>
+                    </TxDtls>
+                </NtryDtls>
+            </Ntry>
+        </Stmt>
+    </BkToCstmrStmt>
+</Document>

--- a/test/data/camt053.v3.json
+++ b/test/data/camt053.v3.json
@@ -209,7 +209,8 @@
                                 "__CLASS__": "Genkgo\\Camt\\Iban",
                                 "getIban": "NL56AGDH9619008421"
                             },
-                            "getIdentification": "NL56AGDH9619008421"
+                            "getIdentification": "NL56AGDH9619008421",
+                            "getName": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",
@@ -236,7 +237,8 @@
                                 "__CLASS__": "Genkgo\\Camt\\Iban",
                                 "getIban": "NL56AGDH9619008421"
                             },
-                            "getIdentification": "NL56AGDH9619008421"
+                            "getIdentification": "NL56AGDH9619008421",
+                            "getName": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",

--- a/test/data/camt053.v4.json
+++ b/test/data/camt053.v4.json
@@ -191,7 +191,8 @@
                                 "__CLASS__": "Genkgo\\Camt\\Iban",
                                 "getIban": "NL56AGDH9619008421"
                             },
-                            "getIdentification": "NL56AGDH9619008421"
+                            "getIdentification": "NL56AGDH9619008421",
+                            "getName": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",
@@ -218,7 +219,8 @@
                                 "__CLASS__": "Genkgo\\Camt\\Iban",
                                 "getIban": "NL56AGDH9619008421"
                             },
-                            "getIdentification": "NL56AGDH9619008421"
+                            "getIdentification": "NL56AGDH9619008421",
+                            "getName": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",

--- a/test/data/camt053.v8.json
+++ b/test/data/camt053.v8.json
@@ -191,7 +191,8 @@
                                 "__CLASS__": "Genkgo\\Camt\\Iban",
                                 "getIban": "NL56AGDH9619008421"
                             },
-                            "getIdentification": "NL56AGDH9619008421"
+                            "getIdentification": "NL56AGDH9619008421",
+                            "getName": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",
@@ -218,7 +219,8 @@
                                 "__CLASS__": "Genkgo\\Camt\\Iban",
                                 "getIban": "NL56AGDH9619008421"
                             },
-                            "getIdentification": "NL56AGDH9619008421"
+                            "getIdentification": "NL56AGDH9619008421",
+                            "getName": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",

--- a/test/data/camt054.v2.with-account-name.json
+++ b/test/data/camt054.v2.with-account-name.json
@@ -15,7 +15,15 @@
             },
             "getBankTransactionCode": {
                 "__CLASS__": "Genkgo\\Camt\\DTO\\BankTransactionCode",
-                "getDomain": null,
+                "getDomain": {
+                    "__CLASS__": "Genkgo\\Camt\\DTO\\DomainBankTransactionCode",
+                    "getCode": "PMNT",
+                    "getFamily": {
+                        "__CLASS__": "Genkgo\\Camt\\DTO\\DomainFamilyBankTransactionCode",
+                        "getCode": "ICDT",
+                        "getSubFamilyCode": "DMCT"
+                    }
+                },
                 "getProprietary": null
             },
             "getBatchPaymentId": null,
@@ -32,7 +40,7 @@
                         "getIban": "CH2801234000123456789"
                     },
                     "getIdentification": "CH2801234000123456789",
-                    "getName": null
+                    "getName": "Account Owner Name"
                 },
                 "getAdditionalInformation": null,
                 "getCopyDuplicateIndicator": null,
@@ -65,29 +73,30 @@
                 },
                 "getCharges": null,
                 "getCreditDebitIndicator": "DBIT",
-                "getReference": {
-                    "__CLASS__": "Genkgo\\Camt\\DTO\\Reference",
-                    "getAccountOwnerTransactionId": null,
-                    "getAccountServicerReference": null,
-                    "getAccountServicerTransactionId": null,
-                    "getChequeNumber": null,
-                    "getClearingSystemReference": null,
-                    "getEndToEndId": null,
-                    "getInstructionId": null,
-                    "getMandateId": null,
-                    "getMarketInfrastructureTransactionId": null,
-                    "getMessageId": null,
-                    "getPaymentInformationId": null,
-                    "getProcessingId": null,
-                    "getProprietaries": [],
-                    "getTransactionId": null,
-                    "getUuidEndToEndReference": "255ae394-9965-4438-ac86-f406feada396"
-                },
+                "getReference": null,
                 "getRelatedAgent": null,
                 "getRelatedAgents": [],
                 "getRelatedDates": null,
-                "getRelatedParties": [],
-                "getRelatedParty": null,
+                "getRelatedParties": [
+                    {
+                        "__CLASS__": "Genkgo\\Camt\\DTO\\RelatedParty",
+                        "getAccount": {
+                            "__CLASS__": "Genkgo\\Camt\\DTO\\IbanAccount",
+                            "getIban": {
+                                "__CLASS__": "Genkgo\\Camt\\Iban",
+                                "getIban": "CH2801234000123456789"
+                            },
+                            "getIdentification": "CH2801234000123456789",
+                            "getName": "Debitor Account Name"
+                        },
+                        "getRelatedPartyType": {
+                            "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",
+                            "getAddress": null,
+                            "getName": "MUELLER"
+                        }
+                    }
+                ],
+                "getRelatedParty": "__RECURSIVITY__",
                 "getRemittanceInformation": null,
                 "getReturnInformation": null
             },
@@ -98,7 +107,7 @@
         }
     ],
     "getGroupHeader": {
-        "__CLASS__": "Genkgo\\Camt\\Camt054\\DTO\\V04\\GroupHeader",
+        "__CLASS__": "Genkgo\\Camt\\DTO\\GroupHeader",
         "getAdditionalInformation": null,
         "getCreatedOn": {
             "__CLASS__": "DateTimeImmutable",
@@ -106,7 +115,6 @@
         },
         "getMessageId": "AAAASESS-FP-ACCR001",
         "getMessageRecipient": null,
-        "getOriginalBusinessQuery": null,
         "getPagination": null
     },
     "getRecords": [

--- a/test/data/camt054.v2.with-account-name.xml
+++ b/test/data/camt054.v2.with-account-name.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:iso:std:iso:20022:tech:xsd:camt.054.001.02">
+    <BkToCstmrDbtCdtNtfctn>
+        <GrpHdr>
+            <MsgId>AAAASESS-FP-ACCR001</MsgId>
+            <CreDtTm>2007-10-18T12:30:00+01:00</CreDtTm>
+        </GrpHdr>
+        <Ntfctn>
+            <Id>AAAASESS-FP-ACCR001</Id>
+            <CreDtTm>2007-10-18T12:30:00+01:00</CreDtTm>
+            <Acct>
+                <Id>
+                    <IBAN>CH2801234000123456789</IBAN>
+                </Id>
+                <Nm>Account Owner Name</Nm>
+            </Acct>
+            <Ntry>
+                <Amt Ccy="SEK">200000</Amt>
+                <CdtDbtInd>DBIT</CdtDbtInd>
+                <Sts>BOOK</Sts>
+                <BkTxCd>
+                    <Domn>
+                        <Cd>PMNT</Cd>
+                        <Fmly>
+                            <Cd>ICDT</Cd>
+                            <SubFmlyCd>DMCT</SubFmlyCd>
+                        </Fmly>
+                    </Domn>
+                </BkTxCd>
+                <NtryDtls>
+                    <TxDtls>
+                        <RltdPties>
+                            <Dbtr>
+                                <Nm>MUELLER</Nm>
+                            </Dbtr>
+                            <DbtrAcct>
+                                <Id>
+                                    <IBAN>CH2801234000123456789</IBAN>
+                                </Id>
+                                <Nm>Debitor Account Name</Nm>
+                            </DbtrAcct>
+                        </RltdPties>
+                    </TxDtls>
+                </NtryDtls>
+            </Ntry>
+        </Ntfctn>
+    </BkToCstmrDbtCdtNtfctn>
+</Document>

--- a/test/data/camt054.v4.json
+++ b/test/data/camt054.v4.json
@@ -46,7 +46,8 @@
                         "__CLASS__": "Genkgo\\Camt\\Iban",
                         "getIban": "CH2801234000123456789"
                     },
-                    "getIdentification": "CH2801234000123456789"
+                    "getIdentification": "CH2801234000123456789",
+                    "getName": null
                 },
                 "getAdditionalInformation": "Additional Information",
                 "getCopyDuplicateIndicator": "CODU",
@@ -161,7 +162,8 @@
                                 "__CLASS__": "Genkgo\\Camt\\Iban",
                                 "getIban": "CH4112345003131313131"
                             },
-                            "getIdentification": "CH4112345003131313131"
+                            "getIdentification": "CH4112345003131313131",
+                            "getName": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",
@@ -188,7 +190,8 @@
                                 "__CLASS__": "Genkgo\\Camt\\Iban",
                                 "getIban": "CH2801234000123456789"
                             },
-                            "getIdentification": "CH2801234000123456789"
+                            "getIdentification": "CH2801234000123456789",
+                            "getName": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",
@@ -312,7 +315,8 @@
                                     "__CLASS__": "Genkgo\\Camt\\Iban",
                                     "getIban": "CH7212345003232323232"
                                 },
-                                "getIdentification": "CH7212345003232323232"
+                                "getIdentification": "CH7212345003232323232",
+                                "getName": null
                             },
                             "getRelatedPartyType": {
                                 "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",
@@ -339,7 +343,8 @@
                                     "__CLASS__": "Genkgo\\Camt\\Iban",
                                     "getIban": "CH2801234000123456789"
                                 },
-                                "getIdentification": "CH2801234000123456789"
+                                "getIdentification": "CH2801234000123456789",
+                                "getName": null
                             },
                             "getRelatedPartyType": {
                                 "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",
@@ -456,7 +461,8 @@
                                     "__CLASS__": "Genkgo\\Camt\\Iban",
                                     "getIban": "CH7212345003232323232"
                                 },
-                                "getIdentification": "CH7212345003232323232"
+                                "getIdentification": "CH7212345003232323232",
+                                "getName": null
                             },
                             "getRelatedPartyType": {
                                 "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",
@@ -483,7 +489,8 @@
                                     "__CLASS__": "Genkgo\\Camt\\Iban",
                                     "getIban": "CH2801234000123456789"
                                 },
-                                "getIdentification": "CH2801234000123456789"
+                                "getIdentification": "CH2801234000123456789",
+                                "getName": null
                             },
                             "getRelatedPartyType": {
                                 "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",

--- a/test/data/camt054.v8-with-financial-institution.json
+++ b/test/data/camt054.v8-with-financial-institution.json
@@ -31,7 +31,8 @@
                         "__CLASS__": "Genkgo\\Camt\\Iban",
                         "getIban": "CH2801234000123456789"
                     },
-                    "getIdentification": "CH2801234000123456789"
+                    "getIdentification": "CH2801234000123456789",
+                    "getName": null
                 },
                 "getAdditionalInformation": null,
                 "getCopyDuplicateIndicator": null,

--- a/test/data/camt054.v8.json
+++ b/test/data/camt054.v8.json
@@ -46,7 +46,8 @@
                         "__CLASS__": "Genkgo\\Camt\\Iban",
                         "getIban": "CH2801234000123456789"
                     },
-                    "getIdentification": "CH2801234000123456789"
+                    "getIdentification": "CH2801234000123456789",
+                    "getName": null
                 },
                 "getAdditionalInformation": "Additional Information",
                 "getCopyDuplicateIndicator": "CODU",
@@ -161,7 +162,8 @@
                                 "__CLASS__": "Genkgo\\Camt\\Iban",
                                 "getIban": "CH4112345003131313131"
                             },
-                            "getIdentification": "CH4112345003131313131"
+                            "getIdentification": "CH4112345003131313131",
+                            "getName": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",
@@ -188,7 +190,8 @@
                                 "__CLASS__": "Genkgo\\Camt\\Iban",
                                 "getIban": "CH2801234000123456789"
                             },
-                            "getIdentification": "CH2801234000123456789"
+                            "getIdentification": "CH2801234000123456789",
+                            "getName": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",
@@ -312,7 +315,8 @@
                                     "__CLASS__": "Genkgo\\Camt\\Iban",
                                     "getIban": "CH7212345003232323232"
                                 },
-                                "getIdentification": "CH7212345003232323232"
+                                "getIdentification": "CH7212345003232323232",
+                                "getName": null
                             },
                             "getRelatedPartyType": {
                                 "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",
@@ -339,7 +343,8 @@
                                     "__CLASS__": "Genkgo\\Camt\\Iban",
                                     "getIban": "CH2801234000123456789"
                                 },
-                                "getIdentification": "CH2801234000123456789"
+                                "getIdentification": "CH2801234000123456789",
+                                "getName": null
                             },
                             "getRelatedPartyType": {
                                 "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",
@@ -456,7 +461,8 @@
                                     "__CLASS__": "Genkgo\\Camt\\Iban",
                                     "getIban": "CH7212345003232323232"
                                 },
-                                "getIdentification": "CH7212345003232323232"
+                                "getIdentification": "CH7212345003232323232",
+                                "getName": null
                             },
                             "getRelatedPartyType": {
                                 "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",
@@ -483,7 +489,8 @@
                                     "__CLASS__": "Genkgo\\Camt\\Iban",
                                     "getIban": "CH2801234000123456789"
                                 },
-                                "getIdentification": "CH2801234000123456789"
+                                "getIdentification": "CH2801234000123456789",
+                                "getName": null
                             },
                             "getRelatedPartyType": {
                                 "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",


### PR DESCRIPTION
`IbanAccount::getName()` return the account name if defined in the CAMT file.

Closes #161