### PR TITLE
Add support for Related party identification structure

### DIFF
--- a/src/DTO/Creditor.php
+++ b/src/DTO/Creditor.php
@@ -8,6 +8,8 @@ class Creditor implements RelatedPartyTypeInterface
 {
     private ?Address $address = null;
 
+    private ?Identification $identification = null;
+
     public function __construct(private ?string $name)
     {
     }
@@ -15,6 +17,11 @@ class Creditor implements RelatedPartyTypeInterface
     public function setAddress(Address $address): void
     {
         $this->address = $address;
+    }
+
+    public function setIdentification(Identification $identification): void
+    {
+        $this->identification = $identification;
     }
 
     public function getAddress(): ?Address
@@ -25,5 +32,10 @@ class Creditor implements RelatedPartyTypeInterface
     public function getName(): ?string
     {
         return $this->name;
+    }
+
+    public function getIdentification(): ?Identification
+    {
+        return $this->identification;
     }
 }

--- a/src/DTO/Debtor.php
+++ b/src/DTO/Debtor.php
@@ -8,6 +8,8 @@ class Debtor implements RelatedPartyTypeInterface
 {
     private ?Address $address = null;
 
+    private ?Identification $identification = null;
+
     public function __construct(private ?string $name)
     {
     }
@@ -15,6 +17,11 @@ class Debtor implements RelatedPartyTypeInterface
     public function setAddress(Address $address): void
     {
         $this->address = $address;
+    }
+
+    public function setIdentification(Identification $identification): void
+    {
+        $this->identification = $identification;
     }
 
     public function getAddress(): ?Address
@@ -25,5 +32,10 @@ class Debtor implements RelatedPartyTypeInterface
     public function getName(): ?string
     {
         return $this->name;
+    }
+
+    public function getIdentification(): ?Identification
+    {
+        return $this->identification;
     }
 }

--- a/src/DTO/PrivateIdentification.php
+++ b/src/DTO/PrivateIdentification.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Genkgo\Camt\DTO;
+
+class PrivateIdentification extends Identification
+{
+    private ?string $birthDate = null;
+
+    private ?string $provinceOfBirth = null;
+
+    private ?string $cityOfBirth = null;
+
+    private ?string $countryOfBirth = null;
+
+    private ?string $otherId = null;
+
+    private ?string $otherIssuer = null;
+
+    private ?string $otherSchemeName = null;
+
+    public function getBirthDate(): ?string
+    {
+        return $this->birthDate;
+    }
+
+    public function setBirthDate(?string $birthDate): void
+    {
+        $this->birthDate = $birthDate;
+    }
+
+    public function getProvinceOfBirth(): ?string
+    {
+        return $this->provinceOfBirth;
+    }
+
+    public function setProvinceOfBirth(?string $provinceOfBirth): void
+    {
+        $this->provinceOfBirth = $provinceOfBirth;
+    }
+
+    public function getCityOfBirth(): ?string
+    {
+        return $this->cityOfBirth;
+    }
+
+    public function setCityOfBirth(?string $cityOfBirth): void
+    {
+        $this->cityOfBirth = $cityOfBirth;
+    }
+
+    public function getCountryOfBirth(): ?string
+    {
+        return $this->countryOfBirth;
+    }
+
+    public function setCountryOfBirth(?string $countryOfBirth): void
+    {
+        $this->countryOfBirth = $countryOfBirth;
+    }
+
+    public function getOtherId(): ?string
+    {
+        return $this->otherId;
+    }
+
+    public function setOtherId(?string $otherId): void
+    {
+        $this->otherId = $otherId;
+    }
+
+    public function getOtherIssuer(): ?string
+    {
+        return $this->otherIssuer;
+    }
+
+    public function setOtherIssuer(?string $otherIssuer): void
+    {
+        $this->otherIssuer = $otherIssuer;
+    }
+
+    public function getOtherSchemeName(): ?string
+    {
+        return $this->otherSchemeName;
+    }
+
+    public function setOtherSchemeName(?string $otherSchemeName): void
+    {
+        $this->otherSchemeName = $otherSchemeName;
+    }
+}

--- a/src/DTO/PrivateIdentification.php
+++ b/src/DTO/PrivateIdentification.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Genkgo\Camt\DTO;
 
+use DateTimeImmutable;
+
 class PrivateIdentification extends Identification
 {
-    private ?string $birthDate = null;
+    private ?DateTimeImmutable $birthDate = null;
 
     private ?string $provinceOfBirth = null;
 
@@ -20,12 +22,12 @@ class PrivateIdentification extends Identification
 
     private ?string $otherSchemeName = null;
 
-    public function getBirthDate(): ?string
+    public function getBirthDate(): ?DateTimeImmutable
     {
         return $this->birthDate;
     }
 
-    public function setBirthDate(?string $birthDate): void
+    public function setBirthDate(?DateTimeImmutable $birthDate): void
     {
         $this->birthDate = $birthDate;
     }

--- a/src/DTO/RelatedPartyTypeInterface.php
+++ b/src/DTO/RelatedPartyTypeInterface.php
@@ -16,4 +16,8 @@ interface RelatedPartyTypeInterface
     public function getAddress(): ?Address;
 
     public function getName(): ?string;
+
+    public function getIdentification(): ?Identification;
+
+    public function setIdentification(Identification $identification): void;
 }

--- a/src/Decoder/EntryTransactionDetail.php
+++ b/src/Decoder/EntryTransactionDetail.php
@@ -123,8 +123,7 @@ abstract class EntryTransactionDetail
         if (isset($xmlPartyDetail->Id)) {
             if (isset($xmlPartyDetail->Id->PrvtId)) {
                 $relatedPartyType->setIdentification(DTOFactory\PrivateIdentification::createFromXml($xmlPartyDetail->Id->PrvtId));
-            }
-            if (isset($xmlPartyDetail->Id->OrgId)) {
+            } elseif (isset($xmlPartyDetail->Id->OrgId)) {
                 $relatedPartyType->setIdentification(DTOFactory\OrganisationIdentification::createFromXml($xmlPartyDetail->Id->OrgId));
             }
         }

--- a/src/Decoder/EntryTransactionDetail.php
+++ b/src/Decoder/EntryTransactionDetail.php
@@ -120,6 +120,15 @@ abstract class EntryTransactionDetail
             $relatedPartyType->setAddress(DTOFactory\Address::createFromXml($xmlPartyDetail->PstlAdr));
         }
 
+        if (isset($xmlPartyDetail->Id)) {
+            if (isset($xmlPartyDetail->Id->PrvtId)) {
+                $relatedPartyType->setIdentification(DTOFactory\PrivateIdentification::createFromXml($xmlPartyDetail->Id->PrvtId));
+            }
+            if (isset($xmlPartyDetail->Id->OrgId)) {
+                $relatedPartyType->setIdentification(DTOFactory\OrganisationIdentification::createFromXml($xmlPartyDetail->Id->OrgId));
+            }
+        }
+
         $relatedParty = new RelatedParty($relatedPartyType, $this->getRelatedPartyAccount($xmlRelatedPartyTypeAccount));
 
         $detail->addRelatedParty($relatedParty);

--- a/src/Decoder/Factory/DTO/PrivateIdentification.php
+++ b/src/Decoder/Factory/DTO/PrivateIdentification.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Genkgo\Camt\Decoder\Factory\DTO;
 
+use Genkgo\Camt\Decoder\Date;
 use Genkgo\Camt\DTO;
 use SimpleXMLElement;
 
@@ -14,7 +15,8 @@ class PrivateIdentification
         $privateIdentification = new DTO\PrivateIdentification();
         if (isset($xmlPrivateIdentification->DtAndPlcOfBirth)) {
             if (isset($xmlPrivateIdentification->DtAndPlcOfBirth->BirthDt)) {
-                $privateIdentification->setBirthDate((string) $xmlPrivateIdentification->DtAndPlcOfBirth->BirthDt);
+                $dateDecoder = new Date();
+                $privateIdentification->setBirthDate($dateDecoder->decode((string) $xmlPrivateIdentification->DtAndPlcOfBirth->BirthDt));
             }
             if (isset($xmlPrivateIdentification->DtAndPlcOfBirth->PrvcOfBirth)) {
                 $privateIdentification->setProvinceOfBirth((string) $xmlPrivateIdentification->DtAndPlcOfBirth->PrvcOfBirth);

--- a/src/Decoder/Factory/DTO/PrivateIdentification.php
+++ b/src/Decoder/Factory/DTO/PrivateIdentification.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Genkgo\Camt\Decoder\Factory\DTO;
+
+use Genkgo\Camt\DTO;
+use SimpleXMLElement;
+
+class PrivateIdentification
+{
+    public static function createFromXml(SimpleXMLElement $xmlPrivateIdentification): DTO\PrivateIdentification
+    {
+        $privateIdentification = new DTO\PrivateIdentification();
+        if (isset($xmlPrivateIdentification->DtAndPlcOfBirth)) {
+            if (isset($xmlPrivateIdentification->DtAndPlcOfBirth->BirthDt)) {
+                $privateIdentification->setBirthDate((string) $xmlPrivateIdentification->DtAndPlcOfBirth->BirthDt);
+            }
+            if (isset($xmlPrivateIdentification->DtAndPlcOfBirth->PrvcOfBirth)) {
+                $privateIdentification->setProvinceOfBirth((string) $xmlPrivateIdentification->DtAndPlcOfBirth->PrvcOfBirth);
+            }
+            if (isset($xmlPrivateIdentification->DtAndPlcOfBirth->CityOfBirth)) {
+                $privateIdentification->setCityOfBirth((string) $xmlPrivateIdentification->DtAndPlcOfBirth->CityOfBirth);
+            }
+            if (isset($xmlPrivateIdentification->DtAndPlcOfBirth->CtryOfBirth)) {
+                $privateIdentification->setCountryOfBirth((string) $xmlPrivateIdentification->DtAndPlcOfBirth->CtryOfBirth);
+            }
+        }
+        if (isset($xmlPrivateIdentification->Othr)) {
+            if (isset($xmlPrivateIdentification->Othr->Id)) {
+                $privateIdentification->setOtherId((string) $xmlPrivateIdentification->Othr->Id);
+            }
+
+            if (isset($xmlPrivateIdentification->Othr->SchmeNm)) {
+                if (isset($xmlPrivateIdentification->Othr->SchmeNm->Cd)) {
+                    $privateIdentification->setOtherSchemeName((string) $xmlPrivateIdentification->Othr->SchmeNm->Cd);
+                }
+                if (isset($xmlPrivateIdentification->Othr->SchmeNm->Prtry)) {
+                    $privateIdentification->setOtherSchemeName((string) $xmlPrivateIdentification->Othr->SchmeNm->Prtry);
+                }
+            }
+            if (isset($xmlPrivateIdentification->Othr->Issr)) {
+                $privateIdentification->setOtherIssuer((string) $xmlPrivateIdentification->Othr->Issr);
+            }
+        }
+
+        return $privateIdentification;
+    }
+}

--- a/test/Unit/Camt053/EndToEndTest.php
+++ b/test/Unit/Camt053/EndToEndTest.php
@@ -264,6 +264,8 @@ class EndToEndTest extends Framework\TestCase
                                     self::assertEquals('NL', $party->getRelatedPartyType()->getAddress()->getCountry());
                                     self::assertEquals([], $party->getRelatedPartyType()->getAddress()->getAddressLines());
                                     self::assertEquals('NL56AGDH9619008421', (string) $party->getAccount()->getIdentification());
+                                    self::assertEquals('455454654', $party->getRelatedPartyType()->getIdentification()->getOtherId());
+                                    self::assertEquals('KBO-BCE', $party->getRelatedPartyType()->getIdentification()->getOtherIssuer());
                                 }
                             } elseif ($party->getRelatedPartyType() instanceof DTO\Debtor) {
                                 if ($party->getRelatedPartyType() instanceof DTO\UltimateDebtor) {

--- a/test/data/camt052.v2.other-account.json
+++ b/test/data/camt052.v2.other-account.json
@@ -132,6 +132,23 @@
                                 "getSubDepartment": null,
                                 "getTownName": null
                             },
+                            "getIdentification": {
+                                "__CLASS__": "Genkgo\\Camt\\DTO\\OrganisationIdentification",
+                                "getBankPartyId": null,
+                                "getBei": null,
+                                "getBic": null,
+                                "getChipsUniversalId": null,
+                                "getDuns": null,
+                                "getEangln": null,
+                                "getIbei": null,
+                                "getIdentification": "455454654",
+                                "getIssuer": null,
+                                "getOtherId": "455454654",
+                                "getOtherIssuer": "KBO-BCE",
+                                "getOtherSchemeName": null,
+                                "getOtherType": null,
+                                "getTaxId": null
+                            },
                             "getName": "Company Name"
                         }
                     },
@@ -160,6 +177,7 @@
                                 "getSubDepartment": null,
                                 "getTownName": null
                             },
+                            "getIdentification": null,
                             "getName": "NAME NAME"
                         }
                     }

--- a/test/data/camt052.v2.with-account-name.json
+++ b/test/data/camt052.v2.with-account-name.json
@@ -85,6 +85,7 @@
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",
                             "getAddress": null,
+                            "getIdentification": null,
                             "getName": "Company Name"
                         }
                     },
@@ -102,6 +103,7 @@
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",
                             "getAddress": null,
+                            "getIdentification": null,
                             "getName": "NAME NAME"
                         }
                     }

--- a/test/data/camt052.v4.json
+++ b/test/data/camt052.v4.json
@@ -212,6 +212,7 @@
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",
                             "getAddress": null,
+                            "getIdentification": null,
                             "getName": "UNIFITS GmbH"
                         }
                     },
@@ -240,6 +241,7 @@
                                 "getSubDepartment": null,
                                 "getTownName": "Example Creditor Town 4 - V1"
                             },
+                            "getIdentification": null,
                             "getName": "Example Creditor 4 - V1"
                         }
                     }

--- a/test/data/camt052.v6.json
+++ b/test/data/camt052.v6.json
@@ -212,6 +212,7 @@
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",
                             "getAddress": null,
+                            "getIdentification": null,
                             "getName": "UNIFITS GmbH"
                         }
                     },
@@ -240,6 +241,7 @@
                                 "getSubDepartment": null,
                                 "getTownName": "Example Creditor Town 6 - V1"
                             },
+                            "getIdentification": null,
                             "getName": "Example Creditor 6 - V1"
                         }
                     }

--- a/test/data/camt053.v2.all-balance-types.json
+++ b/test/data/camt053.v2.all-balance-types.json
@@ -282,6 +282,7 @@
                                 "getSubDepartment": null,
                                 "getTownName": null
                             },
+                            "getIdentification": null,
                             "getName": "Company Name"
                         }
                     }

--- a/test/data/camt053.v2.five.decimals.json
+++ b/test/data/camt053.v2.five.decimals.json
@@ -157,6 +157,7 @@
                                 "getSubDepartment": null,
                                 "getTownName": null
                             },
+                            "getIdentification": null,
                             "getName": "Company Name"
                         }
                     }

--- a/test/data/camt053.v2.minimal.json
+++ b/test/data/camt053.v2.minimal.json
@@ -201,6 +201,23 @@
                                 "getSubDepartment": null,
                                 "getTownName": null
                             },
+                            "getIdentification": {
+                                "__CLASS__": "Genkgo\\Camt\\DTO\\OrganisationIdentification",
+                                "getBankPartyId": null,
+                                "getBei": null,
+                                "getBic": null,
+                                "getChipsUniversalId": null,
+                                "getDuns": null,
+                                "getEangln": null,
+                                "getIbei": null,
+                                "getIdentification": "455454654",
+                                "getIssuer": null,
+                                "getOtherId": "455454654",
+                                "getOtherIssuer": "KBO-BCE",
+                                "getOtherSchemeName": null,
+                                "getOtherType": null,
+                                "getTaxId": null
+                            },
                             "getName": "Company Name"
                         }
                     },
@@ -232,6 +249,7 @@
                                 "getSubDepartment": null,
                                 "getTownName": null
                             },
+                            "getIdentification": null,
                             "getName": "NAME NAME"
                         }
                     }

--- a/test/data/camt053.v2.minimal.ultimate.json
+++ b/test/data/camt053.v2.minimal.ultimate.json
@@ -196,6 +196,7 @@
                                 "getSubDepartment": null,
                                 "getTownName": null
                             },
+                            "getIdentification": null,
                             "getName": "CREDITOR NAME NM"
                         }
                     },
@@ -219,6 +220,7 @@
                                 "getSubDepartment": null,
                                 "getTownName": null
                             },
+                            "getIdentification": null,
                             "getName": "DEBTOR NAME NM"
                         }
                     }

--- a/test/data/camt053.v2.multi.statement.json
+++ b/test/data/camt053.v2.multi.statement.json
@@ -157,6 +157,7 @@
                                 "getSubDepartment": null,
                                 "getTownName": null
                             },
+                            "getIdentification": null,
                             "getName": "Company Name 2"
                         }
                     }

--- a/test/data/camt053.v2.with-account-name.json
+++ b/test/data/camt053.v2.with-account-name.json
@@ -109,6 +109,7 @@
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",
                             "getAddress": null,
+                            "getIdentification": null,
                             "getName": "Company Name"
                         }
                     }

--- a/test/data/camt053.v2.with-party-ids.json
+++ b/test/data/camt053.v2.with-party-ids.json
@@ -3,55 +3,115 @@
     "getEntries": [
         {
             "__CLASS__": "Genkgo\\Camt\\DTO\\Entry",
-            "getAccountServicerReference": "AAAASESS-FP-ACCR-01",
-            "getAdditionalInfo": "Credit",
+            "getAccountServicerReference": null,
+            "getAdditionalInfo": "",
             "getAmount": {
                 "__CLASS__": "Money\\Money",
-                "getAmount": "-20000000",
+                "getAmount": "885",
                 "getCurrency": {
                     "__CLASS__": "Money\\Currency",
-                    "getCode": "SEK"
+                    "getCode": "EUR"
                 }
             },
             "getBankTransactionCode": {
                 "__CLASS__": "Genkgo\\Camt\\DTO\\BankTransactionCode",
-                "getDomain": {
-                    "__CLASS__": "Genkgo\\Camt\\DTO\\DomainBankTransactionCode",
-                    "getCode": "PAYM",
-                    "getFamily": {
-                        "__CLASS__": "Genkgo\\Camt\\DTO\\DomainFamilyBankTransactionCode",
-                        "getCode": "0001",
-                        "getSubFamilyCode": "0003"
-                    }
-                },
+                "getDomain": null,
                 "getProprietary": {
                     "__CLASS__": "Genkgo\\Camt\\DTO\\ProprietaryBankTransactionCode",
-                    "getCode": "XXXX+000+0000+000",
-                    "getIssuer": "ZKA"
+                    "getCode": "544",
+                    "getIssuer": ""
                 }
             },
-            "getBatchPaymentId": "FINP-0055-001",
+            "getBatchPaymentId": null,
             "getBookingDate": {
                 "__CLASS__": "DateTimeImmutable",
-                "0": "2007-10-18T09:15:00+00:00"
+                "0": "2014-12-31T00:00:00+00:00"
             },
             "getCharges": null,
-            "getCreditDebitIndicator": "DBIT",
+            "getCreditDebitIndicator": "CRDT",
             "getIndex": 0,
             "getRecord": {
-                "__CLASS__": "Genkgo\\Camt\\Camt052\\DTO\\Report",
+                "__CLASS__": "Genkgo\\Camt\\Camt053\\DTO\\Statement",
                 "getAccount": {
-                    "__CLASS__": "Genkgo\\Camt\\DTO\\OtherAccount",
-                    "getIdentification": "CH2801234000123456789",
-                    "getIssuer": null,
-                    "getSchemeName": null
+                    "__CLASS__": "Genkgo\\Camt\\DTO\\IbanAccount",
+                    "getIban": {
+                        "__CLASS__": "Genkgo\\Camt\\Iban",
+                        "getIban": "NL26VAYB8060476890"
+                    },
+                    "getIdentification": "NL26VAYB8060476890",
+                    "getName": null
                 },
                 "getAdditionalInformation": "Additional Information",
-                "getBalances": [],
+                "getBalances": [
+                    {
+                        "__CLASS__": "Genkgo\\Camt\\DTO\\Balance",
+                        "getAmount": {
+                            "__CLASS__": "Money\\Money",
+                            "getAmount": "1815",
+                            "getCurrency": {
+                                "__CLASS__": "Money\\Currency",
+                                "getCode": "EUR"
+                            }
+                        },
+                        "getDate": {
+                            "__CLASS__": "DateTimeImmutable",
+                            "0": "2014-12-30T00:00:00+00:00"
+                        },
+                        "getType": "opening"
+                    },
+                    {
+                        "__CLASS__": "Genkgo\\Camt\\DTO\\Balance",
+                        "getAmount": {
+                            "__CLASS__": "Money\\Money",
+                            "getAmount": "-2700",
+                            "getCurrency": {
+                                "__CLASS__": "Money\\Currency",
+                                "getCode": "SEK"
+                            }
+                        },
+                        "getDate": {
+                            "__CLASS__": "DateTimeImmutable",
+                            "0": "2014-12-31T00:00:00+00:00"
+                        },
+                        "getType": "closing"
+                    },
+                    {
+                        "__CLASS__": "Genkgo\\Camt\\DTO\\Balance",
+                        "getAmount": {
+                            "__CLASS__": "Money\\Money",
+                            "getAmount": "3500",
+                            "getCurrency": {
+                                "__CLASS__": "Money\\Currency",
+                                "getCode": "CHF"
+                            }
+                        },
+                        "getDate": {
+                            "__CLASS__": "DateTimeImmutable",
+                            "0": "2014-12-30T00:00:00+00:00"
+                        },
+                        "getType": "opening_available"
+                    },
+                    {
+                        "__CLASS__": "Genkgo\\Camt\\DTO\\Balance",
+                        "getAmount": {
+                            "__CLASS__": "Money\\Money",
+                            "getAmount": "-2700",
+                            "getCurrency": {
+                                "__CLASS__": "Money\\Currency",
+                                "getCode": "JPY"
+                            }
+                        },
+                        "getDate": {
+                            "__CLASS__": "DateTimeImmutable",
+                            "0": "2014-12-31T00:00:00+00:00"
+                        },
+                        "getType": "closing_available"
+                    }
+                ],
                 "getCopyDuplicateIndicator": "CODU",
                 "getCreatedOn": {
                     "__CLASS__": "DateTimeImmutable",
-                    "0": "2007-10-18T11:30:00+00:00"
+                    "0": "2015-03-10T18:43:50+00:00"
                 },
                 "getElectronicSequenceNumber": "12312",
                 "getEntries": [
@@ -61,7 +121,7 @@
                     "__CLASS__": "DateTimeImmutable",
                     "0": "2007-10-18T07:00:00+00:00"
                 },
-                "getId": "AAAASESS-FP-ACCR001",
+                "getId": "253EURNL26VAYB8060476890",
                 "getLegalSequenceNumber": "12312",
                 "getPagination": null,
                 "getToDate": {
@@ -82,32 +142,38 @@
                     "getDomain": null,
                     "getProprietary": {
                         "__CLASS__": "Genkgo\\Camt\\DTO\\ProprietaryBankTransactionCode",
-                        "getCode": "XXXX+000+0000+000",
-                        "getIssuer": "ZKA"
+                        "getCode": "544",
+                        "getIssuer": ""
                     }
                 },
                 "getCharges": null,
-                "getCreditDebitIndicator": "DBIT",
-                "getReference": null,
-                "getRelatedAgent": {
-                    "__CLASS__": "Genkgo\\Camt\\DTO\\RelatedAgent",
-                    "getRelatedAgentType": {
-                        "__CLASS__": "Genkgo\\Camt\\DTO\\CreditorAgent",
-                        "getBIC": "BANKCHZHXXX",
-                        "getName": "Some bank"
-                    }
-                },
-                "getRelatedAgents": [
-                    "__RECURSIVITY__",
-                    {
-                        "__CLASS__": "Genkgo\\Camt\\DTO\\RelatedAgent",
-                        "getRelatedAgentType": {
-                            "__CLASS__": "Genkgo\\Camt\\DTO\\DebtorAgent",
-                            "getBIC": "BANKCHZHXXX",
-                            "getName": "Some bank"
+                "getCreditDebitIndicator": "CRDT",
+                "getReference": {
+                    "__CLASS__": "Genkgo\\Camt\\DTO\\Reference",
+                    "getAccountOwnerTransactionId": null,
+                    "getAccountServicerReference": null,
+                    "getAccountServicerTransactionId": null,
+                    "getChequeNumber": null,
+                    "getClearingSystemReference": null,
+                    "getEndToEndId": null,
+                    "getInstructionId": null,
+                    "getMandateId": null,
+                    "getMarketInfrastructureTransactionId": null,
+                    "getMessageId": null,
+                    "getPaymentInformationId": null,
+                    "getProcessingId": null,
+                    "getProprietaries": [
+                        {
+                            "__CLASS__": "Genkgo\\Camt\\DTO\\ProprietaryReference",
+                            "getReference": "100",
+                            "getType": "LegalSequenceNumber"
                         }
-                    }
-                ],
+                    ],
+                    "getTransactionId": null,
+                    "getUuidEndToEndReference": null
+                },
+                "getRelatedAgent": null,
+                "getRelatedAgents": [],
                 "getRelatedDates": null,
                 "getRelatedParties": [
                     {
@@ -183,13 +249,42 @@
                                 "getSubDepartment": null,
                                 "getTownName": null
                             },
-                            "getIdentification": null,
+                            "getIdentification": {
+                                "__CLASS__": "Genkgo\\Camt\\DTO\\PrivateIdentification",
+                                "getBirthDate": "1912-12-12",
+                                "getCityOfBirth": "Göteborg",
+                                "getCountryOfBirth": "SE",
+                                "getIdentification": null,
+                                "getOtherId": "19121212-1212",
+                                "getOtherIssuer": "Skatteverket",
+                                "getOtherSchemeName": "NIDN",
+                                "getProvinceOfBirth": "Västra Götaland"
+                            },
                             "getName": "NAME NAME"
                         }
                     }
                 ],
                 "getRelatedParty": "__RECURSIVITY__",
-                "getRemittanceInformation": null,
+                "getRemittanceInformation": {
+                    "__CLASS__": "Genkgo\\Camt\\DTO\\RemittanceInformation",
+                    "getCreditorReferenceInformation": {
+                        "__CLASS__": "Genkgo\\Camt\\DTO\\CreditorReferenceInformation",
+                        "getCode": "SCOR",
+                        "getProprietary": null,
+                        "getRef": "4654654654654654"
+                    },
+                    "getMessage": "4654654654654654",
+                    "getStructuredBlock": {
+                        "__CLASS__": "Genkgo\\Camt\\DTO\\StructuredRemittanceInformation",
+                        "getAdditionalRemittanceInformation": null,
+                        "getCreditorReferenceInformation": "__RECURSIVITY__"
+                    },
+                    "getStructuredBlocks": [
+                        "__RECURSIVITY__"
+                    ],
+                    "getUnstructuredBlock": null,
+                    "getUnstructuredBlocks": []
+                },
                 "getReturnInformation": null
             },
             "getTransactionDetails": [
@@ -197,7 +292,7 @@
             ],
             "getValueDate": {
                 "__CLASS__": "DateTimeImmutable",
-                "0": "2007-10-18T00:00:00+00:00"
+                "0": "2015-01-02T00:00:00+00:00"
             }
         }
     ],
@@ -206,9 +301,9 @@
         "getAdditionalInformation": "Group header additional information",
         "getCreatedOn": {
             "__CLASS__": "DateTimeImmutable",
-            "0": "2007-10-18T11:30:00+00:00"
+            "0": "2015-03-10T18:43:50+00:00"
         },
-        "getMessageId": "AAAASESS-FP-ACCR001",
+        "getMessageId": "CAMT053RIB000000000001",
         "getMessageRecipient": {
             "__CLASS__": "Genkgo\\Camt\\DTO\\Recipient",
             "getAddress": {
@@ -244,10 +339,7 @@
             },
             "getName": "COMPANY BVBA"
         },
-        "getPagination": {
-            "__CLASS__": "Genkgo\\Camt\\DTO\\Pagination",
-            "getPageNumber": "1"
-        }
+        "getPagination": null
     },
     "getRecords": [
         "__RECURSIVITY__"

--- a/test/data/camt053.v2.with-party-ids.json
+++ b/test/data/camt053.v2.with-party-ids.json
@@ -251,7 +251,10 @@
                             },
                             "getIdentification": {
                                 "__CLASS__": "Genkgo\\Camt\\DTO\\PrivateIdentification",
-                                "getBirthDate": "1912-12-12",
+                                "getBirthDate": {
+                                    "__CLASS__": "DateTimeImmutable",
+                                    "0": "1912-12-12T00:00:00+00:00"
+                                },
                                 "getCityOfBirth": "Göteborg",
                                 "getCountryOfBirth": "SE",
                                 "getIdentification": null,

--- a/test/data/camt053.v2.with-party-ids.xml
+++ b/test/data/camt053.v2.with-party-ids.xml
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:iso:std:iso:20022:tech:xsd:camt.053.001.02">
+    <BkToCstmrStmt>
+        <GrpHdr>
+            <MsgId>CAMT053RIB000000000001</MsgId>
+            <CreDtTm>2015-03-10T18:43:50+00:00</CreDtTm>
+            <MsgRcpt>
+                <Nm>COMPANY BVBA</Nm>
+                <PstlAdr>
+                    <StrtNm>12 Oxford Street</StrtNm>
+                    <Ctry>UK</Ctry>
+                </PstlAdr>
+                <Id>
+                    <OrgId>
+                        <BICOrBEI>DABAIE2D</BICOrBEI>
+                        <Othr>
+                            <Id>Some other Id</Id>
+                            <Issr>Some other Issuer</Issr>
+                        </Othr>
+                    </OrgId>
+                </Id>
+                <CtryOfRes>NL</CtryOfRes>
+            </MsgRcpt>
+            <AddtlInf>Group header additional information</AddtlInf>
+        </GrpHdr>
+        <Stmt>
+            <Id>253EURNL26VAYB8060476890</Id>
+            <ElctrncSeqNb>12312</ElctrncSeqNb>
+            <LglSeqNb>12312</LglSeqNb>
+            <CreDtTm>2015-03-10T18:43:50+00:00</CreDtTm>
+            <FrToDt>
+                <FrDtTm>2007-10-18T08:00:00+01:00</FrDtTm>
+                <ToDtTm>2007-10-18T12:30:00+01:00</ToDtTm>
+            </FrToDt>
+            <CpyDplctInd>CODU</CpyDplctInd>
+            <Acct>
+                <Id>
+                    <IBAN>NL26VAYB8060476890</IBAN>
+                </Id>
+                <Ccy>EUR</Ccy>
+            </Acct>
+            <Bal>
+                <Tp>
+                    <CdOrPrtry>
+                        <Cd>OPBD</Cd>
+                    </CdOrPrtry>
+                </Tp>
+                <Amt Ccy="EUR">18.15</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <Dt>
+                    <Dt>2014-12-30</Dt>
+                </Dt>
+            </Bal>
+            <Bal>
+                <Tp>
+                    <CdOrPrtry>
+                        <Cd>CLBD</Cd>
+                    </CdOrPrtry>
+                </Tp>
+                <Amt Ccy="SEK">27.00</Amt>
+                <CdtDbtInd>DBIT</CdtDbtInd>
+                <Dt>
+                    <Dt>2014-12-31</Dt>
+                </Dt>
+            </Bal>
+            <Bal>
+                <Tp>
+                    <CdOrPrtry>
+                        <Cd>OPAV</Cd>
+                    </CdOrPrtry>
+                </Tp>
+                <Amt Ccy="CHF">35.00</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <Dt>
+                    <Dt>2014-12-30</Dt>
+                </Dt>
+            </Bal>
+            <Bal>
+                <Tp>
+                    <CdOrPrtry>
+                        <Cd>CLAV</Cd>
+                    </CdOrPrtry>
+                </Tp>
+                <Amt Ccy="JPY">2700</Amt>
+                <CdtDbtInd>DBIT</CdtDbtInd>
+                <Dt>
+                    <Dt>2014-12-31</Dt>
+                </Dt>
+            </Bal>
+            <Ntry>
+                <Amt Ccy="EUR">8.85</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <RvslInd>false</RvslInd>
+                <Sts>BOOK</Sts>
+                <BookgDt>
+                    <Dt>2014-12-31</Dt>
+                </BookgDt>
+                <ValDt>
+                    <Dt>2015-01-02</Dt>
+                </ValDt>
+                <BkTxCd>
+                    <Prtry>
+                        <Cd>544</Cd>
+                    </Prtry>
+                </BkTxCd>
+                <NtryDtls>
+                    <TxDtls>
+                        <Refs>
+                            <Prtry>
+                                <Tp>LegalSequenceNumber</Tp>
+                                <Ref>100</Ref>
+                            </Prtry>
+                        </Refs>
+                        <BkTxCd>
+                            <Prtry>
+                                <Cd>544</Cd>
+                            </Prtry>
+                        </BkTxCd>
+                        <RltdPties>
+                            <Dbtr>
+                                <Nm>NAME NAME</Nm>
+                                <PstlAdr>
+                                    <Ctry>NL</Ctry>
+                                    <AdrLine>ADDR ADDR 10</AdrLine>
+                                    <AdrLine>2000 ANTWERPEN</AdrLine>
+                                </PstlAdr>
+                                <Id>
+                                    <PrvtId>
+                                        <DtAndPlcOfBirth>
+                                            <BirthDt>1912-12-12</BirthDt>
+                                            <PrvcOfBirth>Västra Götaland</PrvcOfBirth>
+                                            <CityOfBirth>Göteborg</CityOfBirth>
+                                            <CtryOfBirth>SE</CtryOfBirth>
+                                        </DtAndPlcOfBirth>
+                                        <Othr>
+                                            <Id>19121212-1212</Id>
+                                            <SchmeNm>
+                                                <Cd>NIDN</Cd>
+                                            </SchmeNm>
+                                            <Issr>Skatteverket</Issr>
+                                        </Othr>
+                                    </PrvtId>
+                                </Id>
+                            </Dbtr>
+                            <DbtrAcct>
+                                <Id>
+                                    <IBAN>NL56AGDH9619008421</IBAN>
+                                </Id>
+                            </DbtrAcct>
+                            <Cdtr>
+                                <Nm>Company Name</Nm>
+                                <PstlAdr>
+                                    <Ctry>NL</Ctry>
+                                </PstlAdr>
+                                <Id>
+                                    <OrgId>
+                                        <Othr>
+                                            <Id>455454654</Id>
+                                            <Issr>KBO-BCE</Issr>
+                                        </Othr>
+                                    </OrgId>
+                                </Id>
+                            </Cdtr>
+                            <CdtrAcct>
+                                <Id>
+                                    <IBAN>NL56AGDH9619008421</IBAN>
+                                </Id>
+                                <Ccy>EUR</Ccy>
+                            </CdtrAcct>
+                        </RltdPties>
+                        <RmtInf>
+                            <Strd>
+                                <CdtrRefInf>
+                                    <Tp>
+                                        <CdOrPrtry>
+                                            <Cd>SCOR</Cd>
+                                        </CdOrPrtry>
+                                        <Issr>BBA</Issr>
+                                    </Tp>
+                                    <Ref>4654654654654654</Ref>
+                                </CdtrRefInf>
+                            </Strd>
+                        </RmtInf>
+                    </TxDtls>
+                </NtryDtls>
+            </Ntry>
+            <AddtlStmtInf>Additional Information</AddtlStmtInf>
+        </Stmt>
+    </BkToCstmrStmt>
+</Document>

--- a/test/data/camt053.v3.json
+++ b/test/data/camt053.v3.json
@@ -226,6 +226,23 @@
                                 "getSubDepartment": null,
                                 "getTownName": null
                             },
+                            "getIdentification": {
+                                "__CLASS__": "Genkgo\\Camt\\DTO\\OrganisationIdentification",
+                                "getBankPartyId": null,
+                                "getBei": null,
+                                "getBic": null,
+                                "getChipsUniversalId": null,
+                                "getDuns": null,
+                                "getEangln": null,
+                                "getIbei": null,
+                                "getIdentification": "455454654",
+                                "getIssuer": null,
+                                "getOtherId": "455454654",
+                                "getOtherIssuer": "KBO-BCE",
+                                "getOtherSchemeName": null,
+                                "getOtherType": null,
+                                "getTaxId": null
+                            },
                             "getName": "Company Name"
                         }
                     },
@@ -257,6 +274,7 @@
                                 "getSubDepartment": null,
                                 "getTownName": null
                             },
+                            "getIdentification": null,
                             "getName": "NAME NAME"
                         }
                     }

--- a/test/data/camt053.v4.json
+++ b/test/data/camt053.v4.json
@@ -208,6 +208,23 @@
                                 "getSubDepartment": null,
                                 "getTownName": null
                             },
+                            "getIdentification": {
+                                "__CLASS__": "Genkgo\\Camt\\DTO\\OrganisationIdentification",
+                                "getBankPartyId": null,
+                                "getBei": null,
+                                "getBic": null,
+                                "getChipsUniversalId": null,
+                                "getDuns": null,
+                                "getEangln": null,
+                                "getIbei": null,
+                                "getIdentification": "455454654",
+                                "getIssuer": null,
+                                "getOtherId": "455454654",
+                                "getOtherIssuer": "KBO-BCE",
+                                "getOtherSchemeName": null,
+                                "getOtherType": null,
+                                "getTaxId": null
+                            },
                             "getName": "Company Name"
                         }
                     },
@@ -239,6 +256,7 @@
                                 "getSubDepartment": null,
                                 "getTownName": null
                             },
+                            "getIdentification": null,
                             "getName": "NAME NAME"
                         }
                     }

--- a/test/data/camt053.v8.json
+++ b/test/data/camt053.v8.json
@@ -208,6 +208,23 @@
                                 "getSubDepartment": null,
                                 "getTownName": null
                             },
+                            "getIdentification": {
+                                "__CLASS__": "Genkgo\\Camt\\DTO\\OrganisationIdentification",
+                                "getBankPartyId": null,
+                                "getBei": null,
+                                "getBic": null,
+                                "getChipsUniversalId": null,
+                                "getDuns": null,
+                                "getEangln": null,
+                                "getIbei": null,
+                                "getIdentification": "455454654",
+                                "getIssuer": null,
+                                "getOtherId": "455454654",
+                                "getOtherIssuer": "KBO-BCE",
+                                "getOtherSchemeName": null,
+                                "getOtherType": null,
+                                "getTaxId": null
+                            },
                             "getName": "Company Name"
                         }
                     },
@@ -239,6 +256,7 @@
                                 "getSubDepartment": null,
                                 "getTownName": null
                             },
+                            "getIdentification": null,
                             "getName": "NAME NAME"
                         }
                     }

--- a/test/data/camt054.v2.json
+++ b/test/data/camt054.v2.json
@@ -107,6 +107,7 @@
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",
                             "getAddress": null,
+                            "getIdentification": null,
                             "getName": "MUELLER"
                         }
                     }
@@ -181,6 +182,7 @@
                             "getRelatedPartyType": {
                                 "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",
                                 "getAddress": null,
+                                "getIdentification": null,
                                 "getName": "MUELLER"
                             }
                         }
@@ -248,6 +250,7 @@
                             "getRelatedPartyType": {
                                 "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",
                                 "getAddress": null,
+                                "getIdentification": null,
                                 "getName": "MUELLER"
                             }
                         }

--- a/test/data/camt054.v2.with-account-name.json
+++ b/test/data/camt054.v2.with-account-name.json
@@ -92,6 +92,7 @@
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",
                             "getAddress": null,
+                            "getIdentification": null,
                             "getName": "MUELLER"
                         }
                     }

--- a/test/data/camt054.v4.json
+++ b/test/data/camt054.v4.json
@@ -179,6 +179,7 @@
                                 "getSubDepartment": null,
                                 "getTownName": "Example Town 3 - V1"
                             },
+                            "getIdentification": null,
                             "getName": "Example Creditor 3 - V1"
                         }
                     },
@@ -196,6 +197,7 @@
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",
                             "getAddress": null,
+                            "getIdentification": null,
                             "getName": "UNIFITS GmbH"
                         }
                     }
@@ -332,6 +334,7 @@
                                     "getSubDepartment": null,
                                     "getTownName": "Example Town 3 - V2"
                                 },
+                                "getIdentification": null,
                                 "getName": "Example Creditor 3 - V2"
                             }
                         },
@@ -349,6 +352,7 @@
                             "getRelatedPartyType": {
                                 "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",
                                 "getAddress": null,
+                                "getIdentification": null,
                                 "getName": "UNIFITS GmbH"
                             }
                         }
@@ -478,6 +482,7 @@
                                     "getSubDepartment": null,
                                     "getTownName": "Example Town 3 - V3"
                                 },
+                                "getIdentification": null,
                                 "getName": "Example Creditor 3 - V3"
                             }
                         },
@@ -495,6 +500,7 @@
                             "getRelatedPartyType": {
                                 "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",
                                 "getAddress": null,
+                                "getIdentification": null,
                                 "getName": "UNIFITS GmbH"
                             }
                         }

--- a/test/data/camt054.v8-with-financial-institution.json
+++ b/test/data/camt054.v8-with-financial-institution.json
@@ -87,6 +87,7 @@
                                 "getSubDepartment": null,
                                 "getTownName": "Example Town 3 - V1"
                             },
+                            "getIdentification": null,
                             "getName": "Example Creditor 3 - V1"
                         }
                     }

--- a/test/data/camt054.v8.json
+++ b/test/data/camt054.v8.json
@@ -179,6 +179,7 @@
                                 "getSubDepartment": null,
                                 "getTownName": "Example Town 3 - V1"
                             },
+                            "getIdentification": null,
                             "getName": "Example Creditor 3 - V1"
                         }
                     },
@@ -196,6 +197,7 @@
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",
                             "getAddress": null,
+                            "getIdentification": null,
                             "getName": "UNIFITS GmbH"
                         }
                     }
@@ -332,6 +334,7 @@
                                     "getSubDepartment": null,
                                     "getTownName": "Example Town 3 - V2"
                                 },
+                                "getIdentification": null,
                                 "getName": "Example Creditor 3 - V2"
                             }
                         },
@@ -349,6 +352,7 @@
                             "getRelatedPartyType": {
                                 "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",
                                 "getAddress": null,
+                                "getIdentification": null,
                                 "getName": "UNIFITS GmbH"
                             }
                         }
@@ -478,6 +482,7 @@
                                     "getSubDepartment": null,
                                     "getTownName": "Example Town 3 - V3"
                                 },
+                                "getIdentification": null,
                                 "getName": "Example Creditor 3 - V3"
                             }
                         },
@@ -495,6 +500,7 @@
                             "getRelatedPartyType": {
                                 "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",
                                 "getAddress": null,
+                                "getIdentification": null,
                                 "getName": "UNIFITS GmbH"
                             }
                         }


### PR DESCRIPTION
This PR resolves issue #167 and partly covers PR #141 

The Id structure used in Related parties is extended to include Private Identification or Organisation Identification. This structure is reused in many parts of the CAMT (and PAIN) but for now implemented in related parties. It could probably be reused in other parts.