### PR TITLE
Expose account servicer on Account DTO

### DIFF
--- a/src/Camt052/Decoder/Message.php
+++ b/src/Camt052/Decoder/Message.php
@@ -20,10 +20,12 @@ abstract class Message extends BaseMessageDecoder
 
         $xmlReports = $this->getRootElement($document)->Rpt;
         foreach ($xmlReports as $xmlReport) {
+            $account = $this->getAccount($xmlReport);
+            $account->setServicer($this->getAccountServicer($xmlReport->Acct));
             $report = new Camt052DTO\Report(
                 (string) $xmlReport->Id,
                 $this->dateDecoder->decode((string) $xmlReport->CreDtTm),
-                $this->getAccount($xmlReport)
+                $account
             );
 
             if (isset($xmlReport->RptPgntn)) {

--- a/src/Camt053/Decoder/Message.php
+++ b/src/Camt053/Decoder/Message.php
@@ -18,10 +18,12 @@ class Message extends BaseMessageDecoder
 
         $xmlStatements = $this->getRootElement($document)->Stmt;
         foreach ($xmlStatements as $xmlStatement) {
+            $account = $this->getAccount($xmlStatement);
+            $account->setServicer($this->getAccountServicer($xmlStatement->Acct));
             $statement = new Camt053DTO\Statement(
                 (string) $xmlStatement->Id,
                 $this->dateDecoder->decode((string) $xmlStatement->CreDtTm),
-                $this->getAccount($xmlStatement)
+                $account
             );
 
             if (isset($xmlStatement->StmtPgntn)) {

--- a/src/Camt054/Decoder/Message.php
+++ b/src/Camt054/Decoder/Message.php
@@ -21,10 +21,12 @@ class Message extends BaseMessageDecoder
         $xmlNotifications = $this->getRootElement($document)->Ntfctn;
         foreach ($xmlNotifications as $xmlNotification) {
             $createdOn = (string) $xmlNotification->CreDtTm;
+            $account = $this->getAccount($xmlNotification);
+            $account->setServicer($this->getAccountServicer($xmlNotification->Acct));
             $notification = new Camt054DTO\Notification(
                 (string) $xmlNotification->Id,
                 $createdOn ? $this->dateDecoder->decode($createdOn) : null,
-                $this->getAccount($xmlNotification)
+                $account
             );
 
             if (isset($xmlNotification->NtfctnPgntn)) {

--- a/src/DTO/Account.php
+++ b/src/DTO/Account.php
@@ -6,5 +6,17 @@ namespace Genkgo\Camt\DTO;
 
 abstract class Account
 {
+    private ?FinancialInstitution $servicer = null;
+
     abstract public function getIdentification(): string;
+
+    public function getServicer(): ?FinancialInstitution
+    {
+        return $this->servicer;
+    }
+
+    public function setServicer(?FinancialInstitution $servicer): void
+    {
+        $this->servicer = $servicer;
+    }
 }

--- a/src/DTO/FinancialInstitution.php
+++ b/src/DTO/FinancialInstitution.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Genkgo\Camt\DTO;
+
+class FinancialInstitution
+{
+    public function __construct(
+        private readonly ?string $bic,
+        private readonly ?string $name,
+    ) {
+    }
+
+    public function getBic(): ?string
+    {
+        return $this->bic;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+}

--- a/src/Decoder/Message.php
+++ b/src/Decoder/Message.php
@@ -71,4 +71,26 @@ abstract class Message
     abstract public function addRecords(DTO\Message $message, SimpleXMLElement $document): void;
 
     abstract public function getRootElement(SimpleXMLElement $document): SimpleXMLElement;
+
+    protected function getAccountServicer(SimpleXMLElement $xmlAccount): ?DTO\FinancialInstitution
+    {
+        if (!isset($xmlAccount->Svcr->FinInstnId)) {
+            return null;
+        }
+
+        $finInstnId = $xmlAccount->Svcr->FinInstnId;
+        $bic = null;
+        if (isset($finInstnId->BICFI)) {
+            $bic = (string) $finInstnId->BICFI;
+        } elseif (isset($finInstnId->BIC)) {
+            $bic = (string) $finInstnId->BIC;
+        }
+        $name = isset($finInstnId->Nm) ? (string) $finInstnId->Nm : null;
+
+        if ($bic === null && $name === null) {
+            return null;
+        }
+
+        return new DTO\FinancialInstitution($bic, $name);
+    }
 }

--- a/test/Unit/Camt054/EndToEndTest.php
+++ b/test/Unit/Camt054/EndToEndTest.php
@@ -120,6 +120,12 @@ class EndToEndTest extends Framework\TestCase
         self::assertInstanceOf(DTO\Pagination::class, $notificationV4->getPagination());
         self::assertEquals('2', $notificationV4->getPagination()->getPageNumber());
         self::assertTrue($notificationV4->getPagination()->isLastPage());
+
+        $notificationV8 = $this->getV8Message()->getRecords()[0];
+        $servicer = $notificationV8->getAccount()->getServicer();
+        self::assertInstanceOf(DTO\FinancialInstitution::class, $servicer);
+        self::assertSame('UBSWCHZH80A', $servicer->getBic());
+        self::assertSame('UBS SWITZERLAND AG', $servicer->getName());
     }
 
     public function testEntries(): void

--- a/test/Unit/Decoder/AccountServicerTest.php
+++ b/test/Unit/Decoder/AccountServicerTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Genkgo\TestCamt\Unit\Decoder;
+
+use Genkgo\Camt\Decoder\Message as BaseMessageDecoder;
+use Genkgo\Camt\DTO;
+use PHPUnit\Framework;
+use ReflectionMethod;
+use SimpleXMLElement;
+
+class AccountServicerTest extends Framework\TestCase
+{
+    private BaseMessageDecoder $decoder;
+
+    private ReflectionMethod $method;
+
+    protected function setUp(): void
+    {
+        $this->decoder = new class($this->createMock(\Genkgo\Camt\Decoder\Record::class), new \Genkgo\Camt\Decoder\Date()) extends BaseMessageDecoder {
+            public function addRecords(DTO\Message $message, SimpleXMLElement $document): void
+            {
+            }
+
+            public function getRootElement(SimpleXMLElement $document): SimpleXMLElement
+            {
+                return $document;
+            }
+        };
+
+        $this->method = new ReflectionMethod(BaseMessageDecoder::class, 'getAccountServicer');
+        $this->method->setAccessible(true);
+    }
+
+    public function testItReturnsNullWhenNoServicer(): void
+    {
+        $xml = new SimpleXMLElement('<Acct><Id><IBAN>DE89370400440532013000</IBAN></Id></Acct>');
+
+        self::assertNull($this->method->invoke($this->decoder, $xml));
+    }
+
+    public function testItExtractsBicFromBicTag(): void
+    {
+        $xml = new SimpleXMLElement('<Acct><Svcr><FinInstnId><BIC>COBADEFFXXX</BIC><Nm>Commerzbank AG</Nm></FinInstnId></Svcr></Acct>');
+
+        $servicer = $this->method->invoke($this->decoder, $xml);
+
+        self::assertInstanceOf(DTO\FinancialInstitution::class, $servicer);
+        self::assertSame('COBADEFFXXX', $servicer->getBic());
+        self::assertSame('Commerzbank AG', $servicer->getName());
+    }
+
+    public function testItExtractsBicFromBicfiTag(): void
+    {
+        $xml = new SimpleXMLElement('<Acct><Svcr><FinInstnId><BICFI>UBSWCHZH80A</BICFI><Nm>UBS SWITZERLAND AG</Nm></FinInstnId></Svcr></Acct>');
+
+        $servicer = $this->method->invoke($this->decoder, $xml);
+
+        self::assertInstanceOf(DTO\FinancialInstitution::class, $servicer);
+        self::assertSame('UBSWCHZH80A', $servicer->getBic());
+        self::assertSame('UBS SWITZERLAND AG', $servicer->getName());
+    }
+
+    public function testItReturnsNameOnlyWhenNoBic(): void
+    {
+        $xml = new SimpleXMLElement('<Acct><Svcr><FinInstnId><Nm>AAAA BANKEN</Nm></FinInstnId></Svcr></Acct>');
+
+        $servicer = $this->method->invoke($this->decoder, $xml);
+
+        self::assertInstanceOf(DTO\FinancialInstitution::class, $servicer);
+        self::assertNull($servicer->getBic());
+        self::assertSame('AAAA BANKEN', $servicer->getName());
+    }
+
+    public function testItReturnsNullWhenFinInstnIdIsEmpty(): void
+    {
+        $xml = new SimpleXMLElement('<Acct><Svcr><FinInstnId></FinInstnId></Svcr></Acct>');
+
+        self::assertNull($this->method->invoke($this->decoder, $xml));
+    }
+}

--- a/test/data/camt052.v1.json
+++ b/test/data/camt052.v1.json
@@ -39,7 +39,8 @@
                 "getAccount": {
                     "__CLASS__": "Genkgo\\Camt\\DTO\\ProprietaryAccount",
                     "getId": "CH2801234000123456789",
-                    "getIdentification": "CH2801234000123456789"
+                    "getIdentification": "CH2801234000123456789",
+                    "getServicer": null
                 },
                 "getAdditionalInformation": "Additional Information",
                 "getBalances": [],

--- a/test/data/camt052.v2.json
+++ b/test/data/camt052.v2.json
@@ -44,7 +44,12 @@
                     "__CLASS__": "Genkgo\\Camt\\DTO\\OtherAccount",
                     "getIdentification": "CH2801234000123456789",
                     "getIssuer": null,
-                    "getSchemeName": null
+                    "getSchemeName": null,
+                    "getServicer": {
+                        "__CLASS__": "Genkgo\\Camt\\DTO\\FinancialInstitution",
+                        "getBic": null,
+                        "getName": "AAAA BANKEN"
+                    }
                 },
                 "getAdditionalInformation": "Additional Information",
                 "getBalances": [],
@@ -119,7 +124,8 @@
                                 "getIban": "NL56AGDH9619008421"
                             },
                             "getIdentification": "NL56AGDH9619008421",
-                            "getName": null
+                            "getName": null,
+                            "getServicer": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",
@@ -164,7 +170,8 @@
                                 "getIban": "NL56AGDH9619008421"
                             },
                             "getIdentification": "NL56AGDH9619008421",
-                            "getName": null
+                            "getName": null,
+                            "getServicer": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",

--- a/test/data/camt052.v2.other-account.json
+++ b/test/data/camt052.v2.other-account.json
@@ -44,7 +44,12 @@
                     "__CLASS__": "Genkgo\\Camt\\DTO\\OtherAccount",
                     "getIdentification": "CH2801234000123456789",
                     "getIssuer": null,
-                    "getSchemeName": null
+                    "getSchemeName": null,
+                    "getServicer": {
+                        "__CLASS__": "Genkgo\\Camt\\DTO\\FinancialInstitution",
+                        "getBic": null,
+                        "getName": "AAAA BANKEN"
+                    }
                 },
                 "getAdditionalInformation": "Additional Information",
                 "getBalances": [],
@@ -116,7 +121,8 @@
                             "__CLASS__": "Genkgo\\Camt\\DTO\\OtherAccount",
                             "getIdentification": "0000000000",
                             "getIssuer": null,
-                            "getSchemeName": null
+                            "getSchemeName": null,
+                            "getServicer": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",
@@ -158,7 +164,8 @@
                             "__CLASS__": "Genkgo\\Camt\\DTO\\OtherAccount",
                             "getIdentification": "1111111111",
                             "getIssuer": null,
-                            "getSchemeName": null
+                            "getSchemeName": null,
+                            "getServicer": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",

--- a/test/data/camt052.v2.with-account-name.json
+++ b/test/data/camt052.v2.with-account-name.json
@@ -32,7 +32,8 @@
                         "getIban": "CH2801234000123456789"
                     },
                     "getIdentification": "CH2801234000123456789",
-                    "getName": "Account Owner Name"
+                    "getName": "Account Owner Name",
+                    "getServicer": null
                 },
                 "getAdditionalInformation": null,
                 "getBalances": [],
@@ -80,7 +81,8 @@
                                 "getIban": "CH2801234000123456789"
                             },
                             "getIdentification": "CH2801234000123456789",
-                            "getName": "Creditor Account Name"
+                            "getName": "Creditor Account Name",
+                            "getServicer": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",
@@ -98,7 +100,8 @@
                                 "getIban": "CH2801234000123456789"
                             },
                             "getIdentification": "CH2801234000123456789",
-                            "getName": "Debitor Account Name"
+                            "getName": "Debitor Account Name",
+                            "getServicer": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",

--- a/test/data/camt052.v4.json
+++ b/test/data/camt052.v4.json
@@ -47,7 +47,12 @@
                         "getIban": "CH2801234000123456789"
                     },
                     "getIdentification": "CH2801234000123456789",
-                    "getName": null
+                    "getName": null,
+                    "getServicer": {
+                        "__CLASS__": "Genkgo\\Camt\\DTO\\FinancialInstitution",
+                        "getBic": "UBSWCHZH80A",
+                        "getName": "UBS SWITZERLAND AG"
+                    }
                 },
                 "getAdditionalInformation": "Additional Information",
                 "getBalances": [
@@ -207,7 +212,8 @@
                                 "getIban": "CH2801234000123456789"
                             },
                             "getIdentification": "CH2801234000123456789",
-                            "getName": null
+                            "getName": null,
+                            "getServicer": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",
@@ -225,7 +231,8 @@
                                 "getIban": "CH2401234004141414141"
                             },
                             "getIdentification": "CH2401234004141414141",
-                            "getName": null
+                            "getName": null,
+                            "getServicer": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",

--- a/test/data/camt052.v6.Amt-zero.json
+++ b/test/data/camt052.v6.Amt-zero.json
@@ -73,7 +73,12 @@
                         "getIban": "CH2801234000123456789"
                     },
                     "getIdentification": "CH2801234000123456789",
-                    "getName": null
+                    "getName": null,
+                    "getServicer": {
+                        "__CLASS__": "Genkgo\\Camt\\DTO\\FinancialInstitution",
+                        "getBic": "UBSWCHZH80A",
+                        "getName": "UBS SWITZERLAND AG"
+                    }
                 },
                 "getAdditionalInformation": "Additional Information",
                 "getBalances": [
@@ -233,7 +238,8 @@
                                 "getIban": "CH2801234000123456789"
                             },
                             "getIdentification": "CH2801234000123456789",
-                            "getName": null
+                            "getName": null,
+                            "getServicer": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",
@@ -251,7 +257,8 @@
                                 "getIban": "CH2401234004141414141"
                             },
                             "getIdentification": "CH2401234004141414141",
-                            "getName": null
+                            "getName": null,
+                            "getServicer": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",

--- a/test/data/camt052.v6.json
+++ b/test/data/camt052.v6.json
@@ -47,7 +47,12 @@
                         "getIban": "CH2801234000123456789"
                     },
                     "getIdentification": "CH2801234000123456789",
-                    "getName": null
+                    "getName": null,
+                    "getServicer": {
+                        "__CLASS__": "Genkgo\\Camt\\DTO\\FinancialInstitution",
+                        "getBic": "UBSWCHZH80A",
+                        "getName": "UBS SWITZERLAND AG"
+                    }
                 },
                 "getAdditionalInformation": "Additional Information",
                 "getBalances": [
@@ -207,7 +212,8 @@
                                 "getIban": "CH2801234000123456789"
                             },
                             "getIdentification": "CH2801234000123456789",
-                            "getName": null
+                            "getName": null,
+                            "getServicer": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",
@@ -225,7 +231,8 @@
                                 "getIban": "CH2401234004141414141"
                             },
                             "getIdentification": "CH2401234004141414141",
-                            "getName": null
+                            "getName": null,
+                            "getServicer": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",

--- a/test/data/camt052.v8.json
+++ b/test/data/camt052.v8.json
@@ -40,7 +40,12 @@
                     "__CLASS__": "Genkgo\\Camt\\DTO\\OtherAccount",
                     "getIdentification": "CH2801234000123456789",
                     "getIssuer": null,
-                    "getSchemeName": null
+                    "getSchemeName": null,
+                    "getServicer": {
+                        "__CLASS__": "Genkgo\\Camt\\DTO\\FinancialInstitution",
+                        "getBic": null,
+                        "getName": "UBSWCHZH80A"
+                    }
                 },
                 "getAdditionalInformation": "Additional Information",
                 "getBalances": [],

--- a/test/data/camt053.v2.all-balance-types.json
+++ b/test/data/camt053.v2.all-balance-types.json
@@ -36,7 +36,12 @@
                     "__CLASS__": "Genkgo\\Camt\\DTO\\OtherAccount",
                     "getIdentification": "CH2801234000123456789",
                     "getIssuer": null,
-                    "getSchemeName": null
+                    "getSchemeName": null,
+                    "getServicer": {
+                        "__CLASS__": "Genkgo\\Camt\\DTO\\FinancialInstitution",
+                        "getBic": null,
+                        "getName": "AAAA BANKEN"
+                    }
                 },
                 "getAdditionalInformation": "Additional Information",
                 "getBalances": [
@@ -266,7 +271,8 @@
                                 "getIban": "NL56AGDH9619008421"
                             },
                             "getIdentification": "NL56AGDH9619008421",
-                            "getName": null
+                            "getName": null,
+                            "getServicer": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",

--- a/test/data/camt053.v2.five.decimals.json
+++ b/test/data/camt053.v2.five.decimals.json
@@ -39,7 +39,8 @@
                         "getIban": "NL26VAYB8060476890"
                     },
                     "getIdentification": "NL26VAYB8060476890",
-                    "getName": null
+                    "getName": null,
+                    "getServicer": null
                 },
                 "getAdditionalInformation": "Additional Information",
                 "getBalances": [
@@ -141,7 +142,8 @@
                                 "getIban": "NL56AGDH9619008421"
                             },
                             "getIdentification": "NL56AGDH9619008421",
-                            "getName": null
+                            "getName": null,
+                            "getServicer": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",

--- a/test/data/camt053.v2.minimal.json
+++ b/test/data/camt053.v2.minimal.json
@@ -39,7 +39,8 @@
                         "getIban": "NL26VAYB8060476890"
                     },
                     "getIdentification": "NL26VAYB8060476890",
-                    "getName": null
+                    "getName": null,
+                    "getServicer": null
                 },
                 "getAdditionalInformation": "Additional Information",
                 "getBalances": [
@@ -185,7 +186,8 @@
                                 "getIban": "NL56AGDH9619008421"
                             },
                             "getIdentification": "NL56AGDH9619008421",
-                            "getName": null
+                            "getName": null,
+                            "getServicer": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",
@@ -230,7 +232,8 @@
                                 "getIban": "NL56AGDH9619008421"
                             },
                             "getIdentification": "NL56AGDH9619008421",
-                            "getName": null
+                            "getName": null,
+                            "getServicer": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",

--- a/test/data/camt053.v2.minimal.ultimate.json
+++ b/test/data/camt053.v2.minimal.ultimate.json
@@ -39,7 +39,8 @@
                         "getIban": "NL26VAYB8060476890"
                     },
                     "getIdentification": "NL26VAYB8060476890",
-                    "getName": null
+                    "getName": null,
+                    "getServicer": null
                 },
                 "getAdditionalInformation": "Additional Information",
                 "getBalances": [

--- a/test/data/camt053.v2.multi.statement.json
+++ b/test/data/camt053.v2.multi.statement.json
@@ -39,7 +39,8 @@
                         "getIban": "NL26VAYB8060476890"
                     },
                     "getIdentification": "NL26VAYB8060476890",
-                    "getName": null
+                    "getName": null,
+                    "getServicer": null
                 },
                 "getAdditionalInformation": "Additional Information",
                 "getBalances": [
@@ -141,7 +142,8 @@
                                 "getIban": "NL56AGDH9619008421"
                             },
                             "getIdentification": "NL56AGDH9619008421",
-                            "getName": null
+                            "getName": null,
+                            "getServicer": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",

--- a/test/data/camt053.v2.with-account-name.json
+++ b/test/data/camt053.v2.with-account-name.json
@@ -39,7 +39,8 @@
                         "getIban": "CH2801234000123456789"
                     },
                     "getIdentification": "CH2801234000123456789",
-                    "getName": "Account Owner Name"
+                    "getName": "Account Owner Name",
+                    "getServicer": null
                 },
                 "getAdditionalInformation": null,
                 "getBalances": [
@@ -104,7 +105,8 @@
                                 "getIban": "CH2801234000123456789"
                             },
                             "getIdentification": "CH2801234000123456789",
-                            "getName": "Creditor Account Name"
+                            "getName": "Creditor Account Name",
+                            "getServicer": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",

--- a/test/data/camt053.v2.with-party-ids.json
+++ b/test/data/camt053.v2.with-party-ids.json
@@ -39,7 +39,8 @@
                         "getIban": "NL26VAYB8060476890"
                     },
                     "getIdentification": "NL26VAYB8060476890",
-                    "getName": null
+                    "getName": null,
+                    "getServicer": null
                 },
                 "getAdditionalInformation": "Additional Information",
                 "getBalances": [
@@ -185,7 +186,8 @@
                                 "getIban": "NL56AGDH9619008421"
                             },
                             "getIdentification": "NL56AGDH9619008421",
-                            "getName": null
+                            "getName": null,
+                            "getServicer": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",
@@ -230,7 +232,8 @@
                                 "getIban": "NL56AGDH9619008421"
                             },
                             "getIdentification": "NL56AGDH9619008421",
-                            "getName": null
+                            "getName": null,
+                            "getServicer": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",

--- a/test/data/camt053.v3.json
+++ b/test/data/camt053.v3.json
@@ -44,7 +44,12 @@
                     "__CLASS__": "Genkgo\\Camt\\DTO\\OtherAccount",
                     "getIdentification": "NL26VAYB8060476890",
                     "getIssuer": null,
-                    "getSchemeName": null
+                    "getSchemeName": null,
+                    "getServicer": {
+                        "__CLASS__": "Genkgo\\Camt\\DTO\\FinancialInstitution",
+                        "getBic": "KREDBEBB",
+                        "getName": null
+                    }
                 },
                 "getAdditionalInformation": "Additional Information",
                 "getBalances": [
@@ -210,7 +215,8 @@
                                 "getIban": "NL56AGDH9619008421"
                             },
                             "getIdentification": "NL56AGDH9619008421",
-                            "getName": null
+                            "getName": null,
+                            "getServicer": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",
@@ -255,7 +261,8 @@
                                 "getIban": "NL56AGDH9619008421"
                             },
                             "getIdentification": "NL56AGDH9619008421",
-                            "getName": null
+                            "getName": null,
+                            "getServicer": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",

--- a/test/data/camt053.v4.json
+++ b/test/data/camt053.v4.json
@@ -40,7 +40,12 @@
                     "__CLASS__": "Genkgo\\Camt\\DTO\\OtherAccount",
                     "getIdentification": "NL26VAYB8060476890",
                     "getIssuer": null,
-                    "getSchemeName": null
+                    "getSchemeName": null,
+                    "getServicer": {
+                        "__CLASS__": "Genkgo\\Camt\\DTO\\FinancialInstitution",
+                        "getBic": null,
+                        "getName": "AAAA BANKEN"
+                    }
                 },
                 "getAdditionalInformation": "Additional Information",
                 "getBalances": [
@@ -192,7 +197,8 @@
                                 "getIban": "NL56AGDH9619008421"
                             },
                             "getIdentification": "NL56AGDH9619008421",
-                            "getName": null
+                            "getName": null,
+                            "getServicer": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",
@@ -237,7 +243,8 @@
                                 "getIban": "NL56AGDH9619008421"
                             },
                             "getIdentification": "NL56AGDH9619008421",
-                            "getName": null
+                            "getName": null,
+                            "getServicer": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",

--- a/test/data/camt053.v8.json
+++ b/test/data/camt053.v8.json
@@ -40,7 +40,12 @@
                     "__CLASS__": "Genkgo\\Camt\\DTO\\OtherAccount",
                     "getIdentification": "NL26VAYB8060476890",
                     "getIssuer": null,
-                    "getSchemeName": null
+                    "getSchemeName": null,
+                    "getServicer": {
+                        "__CLASS__": "Genkgo\\Camt\\DTO\\FinancialInstitution",
+                        "getBic": null,
+                        "getName": "AAAA BANKEN"
+                    }
                 },
                 "getAdditionalInformation": "Additional Information",
                 "getBalances": [
@@ -192,7 +197,8 @@
                                 "getIban": "NL56AGDH9619008421"
                             },
                             "getIdentification": "NL56AGDH9619008421",
-                            "getName": null
+                            "getName": null,
+                            "getServicer": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",
@@ -237,7 +243,8 @@
                                 "getIban": "NL56AGDH9619008421"
                             },
                             "getIdentification": "NL56AGDH9619008421",
-                            "getName": null
+                            "getName": null,
+                            "getServicer": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",

--- a/test/data/camt054.v2.json
+++ b/test/data/camt054.v2.json
@@ -40,7 +40,12 @@
                     "__CLASS__": "Genkgo\\Camt\\DTO\\OtherAccount",
                     "getIdentification": "CH2801234000123456789",
                     "getIssuer": null,
-                    "getSchemeName": null
+                    "getSchemeName": null,
+                    "getServicer": {
+                        "__CLASS__": "Genkgo\\Camt\\DTO\\FinancialInstitution",
+                        "getBic": null,
+                        "getName": "AAAA BANKEN"
+                    }
                 },
                 "getAdditionalInformation": "Additional Information",
                 "getCopyDuplicateIndicator": "CODU",

--- a/test/data/camt054.v2.with-account-name.json
+++ b/test/data/camt054.v2.with-account-name.json
@@ -40,7 +40,8 @@
                         "getIban": "CH2801234000123456789"
                     },
                     "getIdentification": "CH2801234000123456789",
-                    "getName": "Account Owner Name"
+                    "getName": "Account Owner Name",
+                    "getServicer": null
                 },
                 "getAdditionalInformation": null,
                 "getCopyDuplicateIndicator": null,
@@ -87,7 +88,8 @@
                                 "getIban": "CH2801234000123456789"
                             },
                             "getIdentification": "CH2801234000123456789",
-                            "getName": "Debitor Account Name"
+                            "getName": "Debitor Account Name",
+                            "getServicer": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",

--- a/test/data/camt054.v4.json
+++ b/test/data/camt054.v4.json
@@ -47,7 +47,12 @@
                         "getIban": "CH2801234000123456789"
                     },
                     "getIdentification": "CH2801234000123456789",
-                    "getName": null
+                    "getName": null,
+                    "getServicer": {
+                        "__CLASS__": "Genkgo\\Camt\\DTO\\FinancialInstitution",
+                        "getBic": "UBSWCHZH80A",
+                        "getName": "UBS SWITZERLAND AG"
+                    }
                 },
                 "getAdditionalInformation": "Additional Information",
                 "getCopyDuplicateIndicator": "CODU",
@@ -163,7 +168,8 @@
                                 "getIban": "CH4112345003131313131"
                             },
                             "getIdentification": "CH4112345003131313131",
-                            "getName": null
+                            "getName": null,
+                            "getServicer": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",
@@ -192,7 +198,8 @@
                                 "getIban": "CH2801234000123456789"
                             },
                             "getIdentification": "CH2801234000123456789",
-                            "getName": null
+                            "getName": null,
+                            "getServicer": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",
@@ -318,7 +325,8 @@
                                     "getIban": "CH7212345003232323232"
                                 },
                                 "getIdentification": "CH7212345003232323232",
-                                "getName": null
+                                "getName": null,
+                                "getServicer": null
                             },
                             "getRelatedPartyType": {
                                 "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",
@@ -347,7 +355,8 @@
                                     "getIban": "CH2801234000123456789"
                                 },
                                 "getIdentification": "CH2801234000123456789",
-                                "getName": null
+                                "getName": null,
+                                "getServicer": null
                             },
                             "getRelatedPartyType": {
                                 "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",
@@ -466,7 +475,8 @@
                                     "getIban": "CH7212345003232323232"
                                 },
                                 "getIdentification": "CH7212345003232323232",
-                                "getName": null
+                                "getName": null,
+                                "getServicer": null
                             },
                             "getRelatedPartyType": {
                                 "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",
@@ -495,7 +505,8 @@
                                     "getIban": "CH2801234000123456789"
                                 },
                                 "getIdentification": "CH2801234000123456789",
-                                "getName": null
+                                "getName": null,
+                                "getServicer": null
                             },
                             "getRelatedPartyType": {
                                 "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",

--- a/test/data/camt054.v8-grphdr-credttm.json
+++ b/test/data/camt054.v8-grphdr-credttm.json
@@ -40,7 +40,12 @@
                         "getIban": "DE91100000000123456789"
                     },
                     "getIdentification": "DE91100000000123456789",
-                    "getName": null
+                    "getName": null,
+                    "getServicer": {
+                        "__CLASS__": "Genkgo\\Camt\\DTO\\FinancialInstitution",
+                        "getBic": "COBADEFF",
+                        "getName": null
+                    }
                 },
                 "getAdditionalInformation": null,
                 "getCopyDuplicateIndicator": null,
@@ -111,7 +116,8 @@
                                 "getIban": "DE02200505501015871393"
                             },
                             "getIdentification": "DE02200505501015871393",
-                            "getName": null
+                            "getName": null,
+                            "getServicer": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",

--- a/test/data/camt054.v8-ntfctn-credttm.json
+++ b/test/data/camt054.v8-ntfctn-credttm.json
@@ -40,7 +40,12 @@
                         "getIban": "DE91100000000123456789"
                     },
                     "getIdentification": "DE91100000000123456789",
-                    "getName": null
+                    "getName": null,
+                    "getServicer": {
+                        "__CLASS__": "Genkgo\\Camt\\DTO\\FinancialInstitution",
+                        "getBic": "COBADEFF",
+                        "getName": null
+                    }
                 },
                 "getAdditionalInformation": null,
                 "getCopyDuplicateIndicator": null,
@@ -114,7 +119,8 @@
                                 "getIban": "DE02200505501015871393"
                             },
                             "getIdentification": "DE02200505501015871393",
-                            "getName": null
+                            "getName": null,
+                            "getServicer": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",

--- a/test/data/camt054.v8-with-UETR.json
+++ b/test/data/camt054.v8-with-UETR.json
@@ -32,7 +32,8 @@
                         "getIban": "CH2801234000123456789"
                     },
                     "getIdentification": "CH2801234000123456789",
-                    "getName": null
+                    "getName": null,
+                    "getServicer": null
                 },
                 "getAdditionalInformation": null,
                 "getCopyDuplicateIndicator": null,

--- a/test/data/camt054.v8-with-financial-institution.json
+++ b/test/data/camt054.v8-with-financial-institution.json
@@ -32,7 +32,8 @@
                         "getIban": "CH2801234000123456789"
                     },
                     "getIdentification": "CH2801234000123456789",
-                    "getName": null
+                    "getName": null,
+                    "getServicer": null
                 },
                 "getAdditionalInformation": null,
                 "getCopyDuplicateIndicator": null,

--- a/test/data/camt054.v8.json
+++ b/test/data/camt054.v8.json
@@ -47,7 +47,12 @@
                         "getIban": "CH2801234000123456789"
                     },
                     "getIdentification": "CH2801234000123456789",
-                    "getName": null
+                    "getName": null,
+                    "getServicer": {
+                        "__CLASS__": "Genkgo\\Camt\\DTO\\FinancialInstitution",
+                        "getBic": "UBSWCHZH80A",
+                        "getName": "UBS SWITZERLAND AG"
+                    }
                 },
                 "getAdditionalInformation": "Additional Information",
                 "getCopyDuplicateIndicator": "CODU",
@@ -163,7 +168,8 @@
                                 "getIban": "CH4112345003131313131"
                             },
                             "getIdentification": "CH4112345003131313131",
-                            "getName": null
+                            "getName": null,
+                            "getServicer": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",
@@ -192,7 +198,8 @@
                                 "getIban": "CH2801234000123456789"
                             },
                             "getIdentification": "CH2801234000123456789",
-                            "getName": null
+                            "getName": null,
+                            "getServicer": null
                         },
                         "getRelatedPartyType": {
                             "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",
@@ -318,7 +325,8 @@
                                     "getIban": "CH7212345003232323232"
                                 },
                                 "getIdentification": "CH7212345003232323232",
-                                "getName": null
+                                "getName": null,
+                                "getServicer": null
                             },
                             "getRelatedPartyType": {
                                 "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",
@@ -347,7 +355,8 @@
                                     "getIban": "CH2801234000123456789"
                                 },
                                 "getIdentification": "CH2801234000123456789",
-                                "getName": null
+                                "getName": null,
+                                "getServicer": null
                             },
                             "getRelatedPartyType": {
                                 "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",
@@ -466,7 +475,8 @@
                                     "getIban": "CH7212345003232323232"
                                 },
                                 "getIdentification": "CH7212345003232323232",
-                                "getName": null
+                                "getName": null,
+                                "getServicer": null
                             },
                             "getRelatedPartyType": {
                                 "__CLASS__": "Genkgo\\Camt\\DTO\\Creditor",
@@ -495,7 +505,8 @@
                                     "getIban": "CH2801234000123456789"
                                 },
                                 "getIdentification": "CH2801234000123456789",
-                                "getName": null
+                                "getName": null,
+                                "getServicer": null
                             },
                             "getRelatedPartyType": {
                                 "__CLASS__": "Genkgo\\Camt\\DTO\\Debtor",

--- a/test/data/camt53.only-Dt-with-DtTm.json
+++ b/test/data/camt53.only-Dt-with-DtTm.json
@@ -22,7 +22,8 @@
                     "getIban": "GB33BUKB20201555555555"
                 },
                 "getIdentification": "GB33BUKB20201555555555",
-                "getName": null
+                "getName": null,
+                "getServicer": null
             },
             "getAdditionalInformation": null,
             "getBalances": [


### PR DESCRIPTION
## Summary

Implements option C from #182: adds `Account::getServicer(): ?FinancialInstitution`, surfacing the `<Acct><Svcr><FinInstnId>` element on the public DTO surface for CAMT.052, CAMT.053, and CAMT.054 messages.

Downstream consumers can now obtain the servicing bank's BIC and name alongside the account identification, which is the common IBAN+BIC pair needed for reconciliation workflows.

## What changed

- New DTO `Genkgo\Camt\DTO\FinancialInstitution` with `getBic(): ?string` and `getName(): ?string`.
- `Account` gets a nullable `servicer` property with `getServicer()` / `setServicer()`.
- Shared `Decoder\Message::getAccountServicer()` helper extracts `BICFI` (falling back to `BIC`) and `Nm` from `Svcr/FinInstnId`.
- Wired into the 052 / 053 / 054 `addRecords()` paths so the servicer is attached to whatever `Account` subclass `getAccount()` returns (Iban, BBAN, UPIC, Proprietary, Other).
